### PR TITLE
Remove pin from 10gen apt::source.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,6 @@ class mongodb (
     repos       => '10gen',
     key         => '7F0CEB10',
     key_server  => 'keyserver.ubuntu.com',
-    pin         => -10,
     include_src => false,
     before      => Package['mongodb-10gen'],
   }


### PR DESCRIPTION
Remove repo pin. The negative number was causing spec failure on 2.6.
