### PR TITLE
Fix syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ By default ubuntu is upstart and debian uses sysv.
 
 Examples:
 
-    class mongodb {
-      init => 'sysv',
+    class {
+      'mongodb':
+        init => 'sysv';
     }
 
-    class mongodb {
-      enable_10gen => true,
+    class {
+      'mongodb':
+        enable_10gen => true;
     }
 
 ## Supported Platforms


### PR DESCRIPTION
Trivial patch to make the README not complete lies
