### PR TITLE
Accept param for customizing service's enable property

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,5 +106,6 @@ class mongodb (
     ensure    => $service_ensure,
     enable    => $service_enable,
     subscribe => $service_subscribe,
+    require   => Package['mongodb-10gen'],
   }
 }


### PR DESCRIPTION
Similar to the rabbitmq module
allow for the software to be installed and configured but not have the service run at boot.
