### PR TITLE
Added missing name parameter to yumrepo resource.

### DIFF
--- a/manifests/sources/yum.pp
+++ b/manifests/sources/yum.pp
@@ -1,5 +1,6 @@
 class mongodb::sources::yum inherits mongodb::params {
   yumrepo { '10gen':
+    name      => '10gen repo',
     baseurl   => $mongodb::params::baseurl,
     gpgcheck  => '0',
     enabled   => '1',


### PR DESCRIPTION
This is to avoid this annoying warning: Repository '10gen' is missing name in configuration, using id
