### PR TITLE
fixed deprecation warnings on variables references in mongo.conf.erb in puppet 3.3.2

### DIFF
--- a/templates/mongod.conf.erb
+++ b/templates/mongod.conf.erb
@@ -1,13 +1,13 @@
 # mongo.conf - generated from Puppet
 
 #where to log
-logpath=<%= logpath %>
-logappend=<%= logappend %>
+logpath=<%= @logpath %>
+logappend=<%= @logappend %>
 
 # fork and run in background
-fork = <%= mongofork %>
-port = <%= port %>
-dbpath= <%= dbpath %>
+fork = <%= @mongofork %>
+port = <%= @port %>
+dbpath= <%= @dbpath %>
 
 <% if @nojournal %>
 # Disables write-ahead journaling


### PR DESCRIPTION
I just saw these deprecation warnings in puppet 3.3.2:

```
Warning: Variable access via 'logpath' is deprecated. Use '@logpath' instead. template[/tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb]:4
   (at /tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb:4:in `result')
Warning: Variable access via 'logappend' is deprecated. Use '@logappend' instead. template[/tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb]:5
   (at /tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb:5:in `result')
Warning: Variable access via 'mongofork' is deprecated. Use '@mongofork' instead. template[/tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb]:8
   (at /tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb:8:in `result')
Warning: Variable access via 'port' is deprecated. Use '@port' instead. template[/tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb]:9
   (at /tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb:9:in `result')
Warning: Variable access via 'dbpath' is deprecated. Use '@dbpath' instead. template[/tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb]:10
   (at /tmp/vagrant-puppet/modules-0/mongodb/templates/mongod.conf.erb:10:in `result')
```

This patch fixes the deprecation warnings but does not do any version checking for backwards compatibility (not sure if its needed...I'm new here and happy to make appropriate fixes as necessary)
