### PR TITLE
Fixed local variable deprecation warnings

### DIFF
--- a/templates/mongod.conf.erb
+++ b/templates/mongod.conf.erb
@@ -1,13 +1,13 @@
 # mongo.conf - generated from Puppet
 
 #where to log
-logpath=<%= logpath %>
-logappend=<%= logappend %>
+logpath=<%= @logpath %>
+logappend=<%= @logappend %>
 
 # fork and run in background
-fork = <%= mongofork %>
-port = <%= port %>
-dbpath= <%= dbpath %>
+fork = <%= @mongofork %>
+port = <%= @port %>
+dbpath= <%= @dbpath %>
 
 <% if @nojournal %>
 # Disables write-ahead journaling


### PR DESCRIPTION
Before this patch local variables that appeared in the
mongod.conf.erb template were not prefixed with an '@'. This
style is deprecated and produces warnings. This commit fixes
those warnings.
