### PR TITLE
Removed test support for Puppet 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
   - PUPPET_VERSION=3.3.1
   - PUPPET_VERSION=2.7.13
   - PUPPET_VERSION=2.7.6
-  - PUPPET_VERSION=2.6.9
 notifications:
   email: false
 matrix:
@@ -21,5 +20,3 @@ matrix:
       env: PUPPET_VERSION=2.7.13
     - rvm: 1.9.3
       env: PUPPET_VERSION=2.7.6
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=2.6.9


### PR DESCRIPTION
Compatibility for Puppet 2.6 was broken when local varable
reference warning were fixed in templates.
