### PR TITLE
WIP: Initial refactoring work.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,43 @@
+# See README
 class mongodb::params{
+
+  $auth            = undef
+  $cpu             = undef
+  $dbpath_os       = '/var/lib/mongodb/'
+  $enable_10gen    = false
+  $keyfile         = undef
+  $location        = ''
+  $logappend       = true
+  $logpath_os      = '/var/log/mongodb/mongodb.log'
+  $master          = undef
+  $mms_interval    = undef
+  $mms_name        = undef
+  $mms_token       = undef
+  $mongo_group_os  = 'mongodb'
+  $mongo_user_os   = 'mongodb'
+  $noauth          = undef
+  $nohints         = undef
+  $nohttpinterface = undef
+  $nojournal       = undef
+  $noprealloc      = undef
+  $noscripting     = undef
+  $notablescan     = undef
+  $nssize          = undef
+  $objcheck        = undef
+  $only            = undef
+  $oplog           = undef
+  $oplog_size      = undef
+  $port            = '27017'
+  $quota           = undef
+  $replset         = undef
+  $rest            = undef
+  $service_enable  = true
+  $slave           = undef
+  $slowms          = undef
+  $smallfiles      = undef
+  $verbose         = undef
+  $version         = present
+
   case $::osfamily {
     'redhat': {
       $baseurl = "http://downloads-distro.mongodb.org/repo/redhat/os/${::architecture}"
@@ -64,10 +103,6 @@ class mongodb::params{
     }
   }
 
-  $mongo_user_os = 'mongodb'
-  $mongo_group_os = 'mongodb'
+  $servicename = $service
 
-  $dbpath_os = '/var/lib/mongodb/'
-
-  $logpath_os = '/var/log/mongodb/mongodb.log'
 }

--- a/spec/classes/mongodb_spec.rb
+++ b/spec/classes/mongodb_spec.rb
@@ -17,7 +17,7 @@ describe 'mongodb', :type => :class do
         should_not contain_apt__source('10gen')
         should contain_package('mongodb-10gen').with({
           :name => 'mongodb',
-          :ensure => 'installed',
+          :ensure => 'present',
         })
         should contain_file('/etc/mongodb.conf')
         should contain_service('mongodb').with({
@@ -50,7 +50,7 @@ describe 'mongodb', :type => :class do
         })
         should contain_package('mongodb-10gen').with({
           :name   => 'mongodb-10gen',
-          :ensure => 'installed'
+          :ensure => 'present'
         })
       }
     end
@@ -86,7 +86,7 @@ describe 'mongodb', :type => :class do
         should_not contain_apt__source('10gen')
         should contain_package('mongodb-10gen').with({
           :name => 'mongodb',
-          :ensure => 'installed',
+          :ensure => 'present',
         })
         should contain_file('/etc/mongodb.conf')
         should contain_service('mongodb').with({
@@ -169,7 +169,7 @@ describe 'mongodb', :type => :class do
         should_not contain_yumrepo('10gen')
         should contain_package('mongodb-10gen').with({
           :name => 'mongodb-server',
-          :ensure => 'installed',
+          :ensure => 'present',
         })
         should contain_file('/etc/mongodb.conf')
         should contain_service('mongodb').with({

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -24,5 +24,11 @@ RSpec.configure do |c|
     puppet_module_install(:source => proj_root, :module_name => 'mongodb')
     shell('puppet module install puppetlabs-stdlib')
     shell('puppet module install puppetlabs-apt')
+
+    case node.facts['osfamily']
+    when 'RedHat'
+      shell('puppet module install stahnma-epel')
+      puppet_apply('include epel')
+    end
   end
 end

--- a/spec/system/mongodb_config_spec.rb
+++ b/spec/system/mongodb_config_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper_system'
 
 describe 'mongodb::config' do
-  case node.facts['osfamily']
-  when 'RedHat'
-    config_file = '/etc/mongod.conf'
-  when 'Debian'
-    config_file = '/etc/mongodb.conf'
-  end
 
   it 'runs setup' do
     pp = <<-EOS
@@ -15,7 +9,7 @@ describe 'mongodb::config' do
     puppet_apply(pp)
   end
 
-  describe file(config_file) do
+  describe file('/etc/mongodb.conf') do
     it { should be_file }
   end
     

--- a/spec/system/mongodb_service_spec.rb
+++ b/spec/system/mongodb_service_spec.rb
@@ -2,6 +2,13 @@ require 'spec_helper_system'
 
 describe 'mongodb::service' do
 
+  case node.facts['osfamily']
+  when 'RedHat'
+    service_name = 'mongod'
+  else
+    service_name = 'mongodb'
+  end
+
   it 'runs setup' do
     pp = <<-EOS
     class { 'mongodb': }
@@ -9,7 +16,7 @@ describe 'mongodb::service' do
     puppet_apply(pp)
   end
 
-  describe service('mongodb') do
+  describe service(service_name) do
     it { should be_enabled }
     it { should be_running }
   end

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -77,17 +77,17 @@ noprealloc = <%= @noprealloc %>
 # Specify .ns file size for new databases.
  nssize = <%= @nssize %>
 <% end -%>
-<% if @mms_token -%>
+<% if @mmstoken -%>
 # Accout token for Mongo monitoring server.
-mms-token = <%= @mms_token %>
+mms-token = <%= @mmstoken %>
 <% end -%>
-<% if @mms_name -%>
+<% if @mmsname -%>
 # Server name for Mongo monitoring server.
-mms-name = <%= @mms_name %>
+mms-name = <%= @mmsname %>
 <% end -%>
-<% if @mms_interval -%>
+<% if @mmsinterval -%>
 # Ping interval for Mongo monitoring server.
-mms-interval = <%= @mms_interval %>
+mms-interval = <%= @mmsinterval %>
 <% end -%>
 <% if @slave -%>
 slave = <%= @slave %>


### PR DESCRIPTION
[Not ready for merge yet, I want to add 10gen tests too.]

This commit moves all the data into params.pp and reworks the
logic to be less verbose.  I tested this with the rspec-system
tests to make sure it still installs/functions with plain non-10gen
versions.

There's some ugliness I'm unhappy with currently but the intent
of these changes were to change zero functionality so it could
be released prior to the major reworking I desperately want to do
thanks to looking at this.

The super ugliness is around pick(), we have to provide a positive
value to pick() for it to work, but we have defaults that are undef.  To
work around that I test the params default first, and only use pick if
it's non-undef.  If it's undef then we just set the interior variables in
init.pp to that undef value.

The refactoring we should do would be a/ get rid of all undef's
b/ restructure the 10gen vs non-10gen split we have around defaults
so that we create a single set of defaults that can be shared between
the two versions.  We can do it, I'm sure we just chose not to.

If we do that we can remove all the if $enable_10gen{} stuff in init.pp
and directly use the parameters, which is what I'd like to do after this
is merged.
