### PR TITLE
Release 0.3, in preparation for major refactoring.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-mongodb'
-version '0.3.0-rc1'
+version '0.3.0'
 source 'git@github.com:puppetlabs/puppetlabs-mongodb.git'
 author 'puppetlabs'
 license 'Apache License Version 2.0'

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Installs mongodb on RHEL/Ubuntu/Debian from OS repo, or alternatively per 10gen [installation documentation](http://www.mongodb.org/display/DOCS/Ubuntu+and+Debian+packages).
 
+## Deprecation Warning ##
+
+Release 0.3 will be the final prototypical release for the puppetlabs-mongodb module. The development api should
+be considered deprecated and will not work for the forthcoming 1.0 module release. If your project depends
+on the current API, please pin your dependencies to ensure your environments don't break.
+
 ## Usage
 
 ### class mongodb

--- a/spec/system/mongodb_config_spec.rb
+++ b/spec/system/mongodb_config_spec.rb
@@ -1,12 +1,7 @@
 require 'spec_helper_system'
 
 describe 'mongodb::config' do
-  case node.facts['osfamily']
-  when 'RedHat'
-    config_file = '/etc/mongod.conf'
-  when 'Debian'
-    config_file = '/etc/mongodb.conf'
-  end
+  config_file = '/etc/mongodb.conf'
 
   it 'runs setup' do
     pp = <<-EOS


### PR DESCRIPTION
This is the final development release in preparation for a major
refactoring of the puppetlabs-mongodb module. Fixed an rspec-system bug.
Added a deprecation warning.
