### PR TITLE
10Gen repo broken on some 32 bit REHL architectures/variants

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -7,6 +7,7 @@ class mongodb::repo (
       $location = $::architecture ? {
         'x86_64' => 'http://downloads-distro.mongodb.org/repo/redhat/os/x86_64/',
         'i686'   => 'http://downloads-distro.mongodb.org/repo/redhat/os/i686/',
+        'i386'   => 'http://downloads-distro.mongodb.org/repo/redhat/os/i686/',
         default  => undef
       }
       class { 'mongodb::repo::yum': }


### PR DESCRIPTION
Oops, accidentally created this issue without a title by misusing [hub](http://hub.github.com/).

Anyway, this PR is a simple fix for the issue mentioned in #32 - my vagrant box reports i386 instead of i686 so the mongo repo wasn't working on CentOS6.4 (it was not getting a URL).  Adding this makes it all work as expected.
