### PR TITLE
Temporary workaround for failing 1.8.7 Ruby/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ branches:
   only:
     - master
 language: ruby
+before_install:
+  - gem update bundler
+  - bundle --version
+  - gem update --system 2.1.11
+  - gem --version
 bundler_args: --without development
 script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 after_success:


### PR DESCRIPTION
Rubygems broke Travis/Bundler builds on Ruby 1.8.7:
- travis-ci/travis-ci#1793
- rubygems/rubygems#763

This patch is a temporary workaround until rubygems is updated.
