### PR TITLE
Changed gpg auth to use long key for apt repo.

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -9,7 +9,7 @@ class mongodb::repo::apt inherits mongodb::repo {
       location    => $location,
       release     => 'dist',
       repos       => '10gen',
-      key         => '7F0CEB10',
+      key         => '9ECBEC467F0CEB10',
       key_server  => 'keyserver.ubuntu.com',
       include_src => false,
     }


### PR DESCRIPTION
Switched from using the short gpg key to the long gpg
key for verifying the validity of the apt repository.
