### PR TITLE
Fix noauth typo in config

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -16,7 +16,7 @@ class mongodb::server::config {
   $smallfiles      = $mongodb::server::smallfiles
   $cpu             = $mongodb::server::cpu
   $auth            = $mongodb::server::auth
-  $noath           = $mongodb::server::noauth
+  $noauth           = $mongodb::server::noauth
   $verbose         = $mongodb::server::verbose
   $verbositylevel  = $mongodb::server::verbositylevel
   $objcheck        = $mongodb::server::objcheck


### PR DESCRIPTION
There is a typo in config.pp
