### PR TITLE
Followup on 5455a628: Add unit test

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo) do
 
   def create
     alive_members = members_present
-    hostsconf = alive_members.collect.each_with_index.map do |host, id|
+    hostsconf = alive_members.each_with_index.map do |host, id|
       "{ _id: #{id}, host: \"#{host}\" }"
     end.join(',')
     conf = "{ _id: \"#{@resource[:name]}\", members: [ #{hostsconf} ] }"

--- a/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
@@ -21,7 +21,8 @@ describe Puppet::Type.type(:mongodb_replset).provider(:mongo) do
 
   describe 'create' do
     it 'should create a replicaset' do
-      provider.stubs(:mongo_command).returns(
+      provider.stubs(:members_present).returns(valid_members)
+      provider.expects('rs_initiate').with("{ _id: \"rs_test\", members: [ { _id: 0, host: \"mongo1:27017\" },{ _id: 1, host: \"mongo2:27017\" },{ _id: 2, host: \"mongo3:27017\" } ] }", "mongo1:27017").returns(
         { "info" => "Config now saved locally.  Should come online in about a minute.",
           "ok"   => 1 } )
       provider.create


### PR DESCRIPTION
Ruby 1.8 compatibility was fixed for the create method of mongo_replset
provider in commit 5455a628. This change simplifies the fix and adds a
unit test.
