### PR TITLE
mondodb_user provider fails in replicaset

### DIFF
--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -26,11 +26,11 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb) do
 
   def exists?
     block_until_mongodb(@resource[:tries])
-    mongo(@resource[:database], '--quiet', '--eval', "db.system.users.find({user:\"#{@resource[:name]}\"}).count()").strip.eql?('1')
+    mongo(@resource[:database], '--quiet', '--eval', "rs.slaveOk();db.system.users.find({user:\"#{@resource[:name]}\"}).count()").strip.eql?('1')
   end
 
   def password_hash
-    mongo(@resource[:database], '--quiet', '--eval', "db.system.users.findOne({user:\"#{@resource[:name]}\"})[\"pwd\"]").strip
+    mongo(@resource[:database], '--quiet', '--eval', "rs.slaveOk();db.system.users.findOne({user:\"#{@resource[:name]}\"})[\"pwd\"]").strip
   end
 
   def password_hash=(value)
@@ -38,7 +38,7 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb) do
   end
 
   def roles
-    mongo(@resource[:database], '--quiet', '--eval', "db.system.users.findOne({user:\"#{@resource[:name]}\"})[\"roles\"]").strip.split(",").sort
+    mongo(@resource[:database], '--quiet', '--eval', "rs.slaveOk();db.system.users.findOne({user:\"#{@resource[:name]}\"})[\"roles\"]").strip.split(",").sort
   end
 
   def roles=(value)


### PR DESCRIPTION
The mongodb_user provider seems to fail when it tries to evaluate a user on a secondary mongodb instance. Adding rs.slaveOk() to relevant methods solves the problem for our use cases, only tested on a 5 node cluster with no arbiters. Not sure how well this applies to standalone instances of mongodb, or arbiters.
