### PR TITLE
Fixed keyserver 

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -11,7 +11,7 @@ class mongodb::repo::apt inherits mongodb::repo {
       release     => 'dist',
       repos       => '10gen',
       key         => '9ECBEC467F0CEB10',
-      key_server  => 'http://keyserver.ubuntu.com:80',
+      key_server  => 'hkp://keyserver.ubuntu.com:80',
       include_src => false,
     }
 


### PR DESCRIPTION
The access to the keyserver is by default on port 11371. This port could happen to be blocked by default by the firewall on some organizations. I have modified the keyserver so that it accesses port 80. 

I am new to puppet and do not know how to test it. It works if you do it manually
