### PR TITLE
Add an autorequires on ruby-json

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -2,11 +2,17 @@
 # Author: François Charlier <francois.charlier@enovance.com>
 #
 
-require 'json'
-
 Puppet::Type.type(:mongodb_replset).provide(:mongo) do
 
   desc "Manage hosts members for a replicaset."
+
+  confine :true =>
+    begin
+      require 'json'
+      true
+    rescue LoadError
+      false
+    end
 
   commands :mongo => 'mongo'
 

--- a/lib/puppet/type/mongodb_replset.rb
+++ b/lib/puppet/type/mongodb_replset.rb
@@ -26,6 +26,10 @@ Puppet::Type.newtype(:mongodb_replset) do
   end
 
   autorequire(:package) do
+    'ruby-json'
+  end
+
+  autorequire(:package) do
     'mongodb'
   end
 


### PR DESCRIPTION
mongo_replset provider requires json library
for which this commit adds a autorequires
dependency.
