### PR TITLE
Correct location of log file

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class mongodb::params inherits mongodb::globals {
         $service_name = pick($service_name, 'mongod')
         $config      = '/etc/mongod.conf'
         $dbpath      = '/var/lib/mongo'
-        $logpath     = '/var/log/mongo/mongod.log'
+        $logpath     = '/var/log/mongodb/mongod.log'
         $pidfilepath = '/var/run/mongodb/mongod.pid'
         $bind_ip     = pick($bind_ip, ['127.0.0.1'])
         $fork        = true


### PR DESCRIPTION
With $logpath set to /var/log/mongo/mongod.log, starting the mongod service will fail. Upon debugging:

[vagrant@db1 ~]$ sudo runuser -s /bin/bash mongod -c 'ulimit -S -c 0 >/dev/null 2>&1 ;  /usr/bin/mongod  -f /etc/mongod.conf -vvv'
2014-05-21T17:51:47.526+0000 SEVERE: Failed global initialization: FileNotOpen Failed to open "/var/log/mongo/mongod.log"
[vagrant@db1 ~]$ ls -l /var/log/mongo/mongod.log
ls: cannot access /var/log/mongo/mongod.log: No such file or directory
[vagrant@db1 ~]$ ls -al /var/log/mongo/
ls: cannot access /var/log/mongo/: No such file or directory
[vagrant@db1 ~]$ ls -al /var/log/mongodb/mongod.log 
-rw-r----- 1 mongod mongod 0 May  9 20:36 /var/log/mongodb/mongod.log
