### PR TITLE
Proxy safe keyserver address

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -11,7 +11,7 @@ class mongodb::repo::apt inherits mongodb::repo {
       release     => 'dist',
       repos       => '10gen',
       key         => '9ECBEC467F0CEB10',
-      key_server  => 'keyserver.ubuntu.com',
+      key_server  => 'hkp://keyserver.ubuntu.com:80',
       include_src => false,
     }
 


### PR DESCRIPTION
When I use this great puppet module from behind the very restrictive proxy i fall into the problem, that is described here http://askubuntu.com/questions/134913/cant-add-repo-keys and this little fix solve it ;)
