### PR TITLE
Fix mongodb database existance check

### DIFF
--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb) do
 
   def exists?
     block_until_mongodb(@resource[:tries])
-    mongo("--quiet", "--eval", 'db.getMongo().getDBNames()').split(",").include?(@resource[:name])
+    mongo("--quiet", "--eval", 'db.getMongo().getDBNames()').chomp.split(",").include?(@resource[:name])
   end
 
 end


### PR DESCRIPTION
The mongodb_database provider is not properly detecting the presence of the last database in a list of databases with mongodb enterprise (specifically tested on 2.6.0). I do not know if this impacts other versions of mongodb.

getDBNames() is returning a newline (\n) and so fails the exists test as demonstrated in the following ruby code example:
# !/usr/bin/ruby

p %x(/usr/bin/mongo --quiet --eval 'db.getMongo().getDBNames()').split(",")
p %x(/usr/bin/mongo --quiet --eval 'db.getMongo().getDBNames()').split(",").include?('mydb2')
# /tmp/test.rb

["mydb1", "admin", "local", "mydb2\n"]
false

A chomp should be added to strip any newlines as demonstrated in the following ruby code example:
# !/usr/bin/ruby

p %x(/usr/bin/mongo --quiet --eval 'db.getMongo().getDBNames()').chomp.split(",")
p %x(/usr/bin/mongo --quiet --eval 'db.getMongo().getDBNames()').chomp.split(",").include?('mydb2')
# /tmp/test2.rb

["mydb1", "admin", "local", "mydb2"]
true
