### PR TITLE
(MODULES-690) - Rebase of #115 and fix other problems.

### DIFF
--- a/lib/puppet/provider/mongodb_conn_validator/tcp_port.rb
+++ b/lib/puppet/provider/mongodb_conn_validator/tcp_port.rb
@@ -1,0 +1,53 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet/util/mongodb_validator'
+
+# This file contains a provider for the resource type `mongodb_conn_validator`,
+# which validates the mongodb connection by attempting an https connection.
+
+Puppet::Type.type(:mongodb_conn_validator).provide(:tcp_port) do
+  desc "A provider for the resource type `mongodb_conn_validator`,
+        which validates the mongodb connection by attempting an https
+        connection to the mongodb server.  Uses the puppet SSL certificate
+        setup from the local puppet environment to authenticate."
+
+  def exists?
+    start_time = Time.now
+    timeout = resource[:timeout]
+
+    success = validator.attempt_connection
+
+    while success == false && ((Time.now - start_time) < timeout)
+      # It can take several seconds for the mongodb server to start up;
+      # especially on the first install.  Therefore, our first connection attempt
+      # may fail.  Here we have somewhat arbitrarily chosen to retry every 4
+      # seconds until the configurable timeout has expired.
+      Puppet.debug("Failed to connect to mongodb; sleeping 4 seconds before retry")
+      sleep 4
+      success = validator.attempt_connection
+    end
+
+    if success
+      Puppet.debug("Connected to mongodb in #{Time.now - start_time} seconds.")
+    else
+      Puppet.notice("Failed to connect to mongodb within timeout window of #{timeout} seconds; giving up.")
+    end
+
+    success
+  end
+
+  def create
+    # If `#create` is called, that means that `#exists?` returned false, which
+    # means that the connection could not be established... so we need to
+    # cause a failure here.
+    raise Puppet::Error, "Unable to connect to mongodb server! (#{@validator.mongodb_server}:#{@validator.mongodb_port})"
+  end
+
+  private
+
+  # @api private
+  def validator
+    @validator ||= Puppet::Util::MongodbValidator.new(resource[:server], resource[:port])
+  end
+
+end
+

--- a/lib/puppet/type/mongodb_conn_validator.rb
+++ b/lib/puppet/type/mongodb_conn_validator.rb
@@ -1,0 +1,40 @@
+Puppet::Type.newtype(:mongodb_conn_validator) do
+
+  @doc = "Verify that a connection can be successfully established between a node
+          and the mongodb server.  Its primary use is as a precondition to
+          prevent configuration changes from being applied if the mongodb
+          server cannot be reached, but it could potentially be used for other
+          purposes such as monitoring."
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:server) do
+    desc 'The DNS name or IP address of the server where mongodb should be running.'
+  end
+
+  newparam(:port) do
+    desc 'The port that the mongodb server should be listening on.'
+  end
+
+  newparam(:timeout) do
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that puppetdb is not running; defaults to 60 seconds.'
+    defaultto 60
+
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+end

--- a/lib/puppet/util/mongodb_validator.rb
+++ b/lib/puppet/util/mongodb_validator.rb
@@ -1,0 +1,37 @@
+require 'socket'
+require 'timeout'
+
+
+module Puppet
+  module Util
+    class MongodbValidator
+      attr_reader :mongodb_server
+      attr_reader :mongodb_port
+
+      def initialize(mongodb_server, mongodb_port)
+        @mongodb_server = mongodb_server
+        @mongodb_port   = mongodb_port
+      end
+
+      # Utility method; attempts to make an https connection to the mongodb server.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        Timeout::timeout(Puppet[:configtimeout]) do
+          begin
+            TCPSocket.new(@mongodb_server, @mongodb_port).close
+            true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
+            Puppet.debug "Unable to connect to mongodb server (#{@mongodb_server}:#{@mongodb_port}): #{e.message}"
+            false
+          end
+        end
+      rescue Timeout::Error
+        false
+      end
+    end
+  end
+end
+

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -12,15 +12,5 @@ class mongodb::client (
   $ensure       = $mongodb::params::ensure_client,
   $package_name = $mongodb::params::client_package_name,
 ) inherits mongodb::params {
-  case $::osfamily {
-    'RedHat', 'Linux': {
-      class { 'mongodb::client::install': }
-    }
-    'Debian': {
-      warning ('Debian client is included by default with server. Please use ::mongodb::server to install the mongo client for Debian family systems.')
-    }
-    default: {
-      # no action taken, failure happens in params.pp
-    }
-  }
+  class { 'mongodb::client::install': }
 }

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -18,9 +18,11 @@ class mongodb::client::install {
     }
   }
 
-  package { 'mongodb_client':
-    ensure  => $my_package_ensure,
-    name    => $package_name,
-    tag     => 'mongodb',
+  if $package_name {
+    package { 'mongodb_client':
+      ensure  => $my_package_ensure,
+      name    => $package_name,
+      tag     => 'mongodb',
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class mongodb::params inherits mongodb::globals {
         }
         $service_name = pick($::mongodb::globals::service_name, 'mongod')
         $config      = '/etc/mongod.conf'
-        $dbpath      = '/var/lib/mongo'
+        $dbpath      = '/var/lib/mongodb'
         $logpath     = '/var/log/mongodb/mongod.log'
         $pidfilepath = '/var/run/mongodb/mongod.pid'
         $bind_ip     = pick($bind_ip, ['127.0.0.1'])
@@ -56,7 +56,7 @@ class mongodb::params inherits mongodb::globals {
           $client_package_name = pick($::mongodb::globals::client_package_name, 'mongodb-org-shell')
         }
         $service_name = pick($::mongodb::globals::service_name, 'mongod')
-        $config       = '/etc/mongodb.conf'
+        $config       = '/etc/mongod.conf'
         $dbpath       = '/var/lib/mongodb'
         $logpath      = '/var/log/mongodb/mongodb.log'
         $bind_ip      = ['127.0.0.1']
@@ -68,7 +68,7 @@ class mongodb::params inherits mongodb::globals {
         $user                = pick($user, 'mongodb')
         $group               = pick($group, 'mongodb')
         $server_package_name = pick($server_package_name, 'mongodb-server')
-        $client_package_name = pick($client_package_name, 'mongodb')
+        $client_package_name = $client_package_name
         $service_name        = pick($service_name, 'mongodb')
         $config              = '/etc/mongodb.conf'
         $dbpath              = '/var/lib/mongodb'

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -4,6 +4,8 @@ class mongodb::server::service {
   $service_name     = $mongodb::server::service_name
   $service_provider = $mongodb::server::service_provider
   $service_status   = $mongodb::server::service_status
+  $bind_ip          = $mongodb::server::bind_ip
+  $port             = $mongodb::server::port
 
   $service_ensure = $ensure ? {
     present => true,
@@ -19,5 +21,13 @@ class mongodb::server::service {
     provider  => $service_provider,
     hasstatus => true,
     status    => $service_status,
+  }
+  if $service_ensure {
+    mongodb_conn_validator { "mongodb":
+      server  => $bind_ip,
+      port    => $port,
+      timeout => '240',
+      require => Service['mongodb'],
+    }
   }
 }

--- a/spec/acceptance/nodesets/multi-centos-64-x64.yml
+++ b/spec/acceptance/nodesets/multi-centos-64-x64.yml
@@ -1,10 +1,17 @@
 HOSTS:
-  centos-64-x64:
+  'master':
     roles:
       - master
     platform: el-6-x86_64
+    hypervisor : vagrant
     box : centos-64-x64-vbox4210-nocm
     box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
+  'slave':
+    roles:
+      - master
+    platform: el-6-x86_64
     hypervisor : vagrant
+    box : centos-64-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
 CONFIG:
   type: foss

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -10,9 +10,9 @@ describe 'mongodb::server class' do
         service_name = 'mongod'
         config_file  = '/etc/mongod.conf'
       when 'Debian'
-        package_name = 'mongodbdb-org-10gen'
-        service_name = 'mongodb'
-        config_file  = '/etc/mongodb.conf'
+        package_name = 'mongodb-org-server'
+        service_name = 'mongod'
+        config_file  = '/etc/mongod.conf'
       end
     else
       case fact('osfamily')
@@ -43,19 +43,11 @@ describe 'mongodb::server class' do
       end
 
       it 'should work with no errors' do
-        case fact('osfamily')
-        when 'RedHat'
-          pp = <<-EOS
-            class { 'mongodb::globals': manage_package_repo => #{tengen}, }
-            -> class { 'mongodb::server': }
-            -> class { 'mongodb::client': }
-          EOS
-        when 'Debian'
-          pp = <<-EOS
-            class { 'mongodb::globals': manage_package_repo => #{tengen}, }
-            -> class { 'mongodb::server': }
-          EOS
-        end
+        pp = <<-EOS
+          class { 'mongodb::globals': manage_package_repo => #{tengen}, }
+          -> class { 'mongodb::server': }
+          -> class { 'mongodb::client': }
+        EOS
 
         apply_manifest(pp, :catch_failures => true)
         apply_manifest(pp, :catch_changes  => true)
@@ -75,10 +67,7 @@ describe 'mongodb::server class' do
       end
 
       describe port(27017) do
-        it do
-          sleep(20)
-          should be_listening
-        end
+        it { should be_listening }
       end
 
       describe command(client_name) do
@@ -93,6 +82,7 @@ describe 'mongodb::server class' do
         pp = <<-EOS
           class { 'mongodb::globals': manage_package_repo => #{tengen}, }
           -> class { 'mongodb::server': port => 27018, }
+          -> class { 'mongodb::client': }
         EOS
 
         apply_manifest(pp, :catch_failures => true)
@@ -100,8 +90,7 @@ describe 'mongodb::server class' do
       end
 
       describe port(27018) do
-        sleep(20)
-        it { sleep 5 ; should be_listening }
+        it { should be_listening }
       end
     end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -33,7 +33,7 @@ RSpec.configure do |c|
     when 'RedHat'
       on hosts, 'puppet module install stahnma-epel'
       apply_manifest_on hosts, 'include epel'
+      on hosts, 'service iptables stop'
     end
-    on hosts, 'service iptables stop'
   end
 end


### PR DESCRIPTION
- Add `mongodb_conn_validator` resource to block until the service is
  ready to accept connections. Goodbye sleeps! (May lead to increased
  puppet runtimes due to mongodb being so slow.)
- Make `Class['mongodb::client']` work on debian if a client package is
  available, such as when using the mongodb official upstream repo.
  Otherwise the class is a noop. This class used to just raise a warning
  on debian and do nothing ever, which meant you couldn't install the
  upstream mongodb client shell.
- Correct dbpath, config path, and client package name on debian.
- Update the tests and remove all the sleeps

Closes #115
