### PR TITLE
Change to using eql true/false syntax

### DIFF
--- a/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
@@ -28,7 +28,7 @@ describe Puppet::Type.type(:mongodb_database).provider(:mongodb) do
   describe 'exists?' do
     it 'checks if database exists' do
       provider.expects(:mongo).at_least(2).returns("db1,new_database,db2")
-      provider.exists?.should be_true
+      provider.exists?.should eql true
     end
   end
 

--- a/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
@@ -44,7 +44,7 @@ describe Puppet::Type.type(:mongodb_replset).provider(:mongo) do
 }
 EOT
         provider.class.prefetch(resources)
-        resource.provider.exists?.should be_false
+        resource.provider.exists?.should eql false
       end
     end
 
@@ -58,7 +58,7 @@ EOT
 }
 EOT
         provider.class.prefetch(resources)
-        resource.provider.exists?.should be_true
+        resource.provider.exists?.should eql true
       end
     end
   end

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
   describe 'exists?' do
     it 'checks if user exists' do
       provider.expects(:mongo).at_least(2).returns("1")
-      provider.exists?.should be_true
+      provider.exists?.should eql true
     end
   end
 


### PR DESCRIPTION
Tests in Travis were red :-1:

eg:

```
1) Puppet::Type::Mongodb_replset::ProviderMongo#exists? when the replicaset does not exist returns false
     Failure/Error: resource.provider.exists?.should be_false
       expected false to respond to `false?`
```

For some reason the be_false syntax wasn't working? I've changed them to eql true and it's all green now...

Tests are now green :+1:
