### PR TITLE
Handle multiple listers (Error: Can't convert Array into String)

### DIFF
--- a/lib/puppet/type/mongodb_conn_validator.rb
+++ b/lib/puppet/type/mongodb_conn_validator.rb
@@ -16,7 +16,10 @@ Puppet::Type.newtype(:mongodb_conn_validator) do
   end
 
   newparam(:server) do
-    desc 'The DNS name or IP address of the server where mongodb should be running.'
+    desc 'An array containing DNS names or IP addresses of the server where mongodb should be running.'
+    munge do |value|
+      value.first
+    end
   end
 
   newparam(:port) do


### PR DESCRIPTION
Fix issue Array/String conversion when multiple bind_ip's are specified. E.g:

```
class {  '::mongodb::server':
  bind_ip => ['127.0.0.1','10.10.10.10']
}
```

Was throwing an error 'Could not evaluate: can't convert Array to into String'
