### PR TITLE
Fix #123 comment for non-array bind_ips

### DIFF
--- a/lib/puppet/type/mongodb_conn_validator.rb
+++ b/lib/puppet/type/mongodb_conn_validator.rb
@@ -18,7 +18,7 @@ Puppet::Type.newtype(:mongodb_conn_validator) do
   newparam(:server) do
     desc 'An array containing DNS names or IP addresses of the server where mongodb should be running.'
     munge do |value|
-      value.first
+      Array(value).first
     end
   end
 


### PR DESCRIPTION
A bug was introduced that assumed bind_ip was an array and took the
first one, but often it is not an array, so we should cast to an array
and take the first value. This should work on strings and arrays.
