### PR TITLE
remove duplicate directoryperdb from template

### DIFF
--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -161,9 +161,6 @@ slowms = <%= @slowms %>
 # Specify the path to a key file to store authentication information.
 keyFile = <%= @keyfile %>
 <% end -%>
-<% if @directoryperdb -%>
-directoryperdb = <%= @directoryperdb %>
-<% end -%>
 <% if @set_parameter -%>
 setParameter = <%= @set_parameter %>
 <% end -%>


### PR DESCRIPTION
This will cause mongo to fail to start with a duplicate declaration in the configuration.  
