### PR TITLE
pidfilepath can not have spaces.

### DIFF
--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -22,7 +22,7 @@ port = <%= @port %>
 dbpath=<%= @dbpath %>
 <% if @pidfilepath -%>
 # location of pidfile
-pidfilepath = <%= @pidfilepath %>
+pidfilepath=<%= @pidfilepath %>
 <% end -%>
 <% if @nojournal and not @journal -%>
 # Disables write-ahead journaling


### PR DESCRIPTION
If the pidfile has spaces (pidfilepath = /var/run/mongodb/mongodb.pid) then you can not stop the service.
I am using version 2.6.3 from downloads-distro.mongodb.org

$sudo /etc/init.d/mongod stop
Stopping mongod:                                           [FAILED]
