### PR TITLE
Create parent directory of $logpath

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -54,6 +54,9 @@ class mongodb::server::config {
 
   if ($logpath and $syslog) { fail('You cannot use syslog with logpath')}
 
+  $logpath_list = split($logpath, '/')
+  $logdir = join(delete_at($logpath_list, -1), '/')
+
   if ($ensure == 'present' or $ensure == true) {
 
     # Exists for future compatibility and clarity.
@@ -73,6 +76,14 @@ class mongodb::server::config {
     }
 
     file { $dbpath:
+      ensure  => directory,
+      mode    => '0755',
+      owner   => $user,
+      group   => $group,
+      require => File[$config]
+    }
+
+    file { $logdir:
       ensure  => directory,
       mode    => '0755',
       owner   => $user,


### PR DESCRIPTION
We don't use /var/log for application logs on our AWS instances and instead use the much larger ephemeral disks for our logs.
