### PR TITLE
do not use subdirectory for PID file

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,7 @@ class mongodb::params inherits mongodb::globals {
         $config      = '/etc/mongod.conf'
         $dbpath      = '/var/lib/mongodb'
         $logpath     = '/var/log/mongodb/mongod.log'
-        $pidfilepath = '/var/run/mongodb/mongod.pid'
+        $pidfilepath = '/var/run/mongod.pid'
         $bind_ip     = pick($bind_ip, ['127.0.0.1'])
         $fork        = true
       } else {
@@ -40,7 +40,7 @@ class mongodb::params inherits mongodb::globals {
         $dbpath              = '/var/lib/mongodb'
         $logpath             = '/var/log/mongodb/mongodb.log'
         $bind_ip             = pick($bind_ip, ['127.0.0.1'])
-        $pidfilepath         = '/var/run/mongodb/mongodb.pid'
+        $pidfilepath         = '/var/run/mongod.pid'
         $fork                = true
         $journal             = true
       }


### PR DESCRIPTION
PID file is currently stored in /var/run/mongodb/
However, /var/run and /var/lock are mounted as tmpfs.

So if the subdirectory is not managed by the init script (which is not
the case in MongoDB packaging), the service won't start after a reboot,
since PID subdirectory is not created.

By changing the path of PID file to /var/run/mongod.pid fix the issue,
since there is no need to create a directory.
