### PR TITLE
Reverted to short key format, according to http://docs.mongodb.org/manua...

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -10,7 +10,7 @@ class mongodb::repo::apt inherits mongodb::repo {
       location    => $::mongodb::repo::location,
       release     => 'dist',
       repos       => '10gen',
-      key         => '9ECBEC467F0CEB10',
+      key         => '7F0CEB10',
       key_server  => 'hkp://keyserver.ubuntu.com:80',
       include_src => false,
     }


### PR DESCRIPTION
...l/tutorial/install-mongodb-on-ubuntu/. Long key format did install the key, but was causing repetitive installs as apt-key check presence showed the short format on each puppetrun, quite inconvenient.
