### PR TITLE
Fix typo in README so that puppet code formatting gets applied.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ class {'::mongodb::server':
 
 For Red Hat family systems, the client can be installed in a similar fashion:
 
-```
-puppet class {'::mongodb::client':}
+```puppet
+class {'::mongodb::client':}
 ```
 
 Note that for Debian/Ubuntu family systems the client is installed with the 


### PR DESCRIPTION
The README.md file currently shows how to classify a system for a mongo client, but the 'puppet' specification for the code syntax highlighting is on the wrong line.  This commit moves it up a line, so that it sets the syntax coloring, rather than showing up in the code block itself.
