### PR TITLE
Bugfix: $bind_ip is not taken in account on Debian systems provisioned with the 10gen/mongodb repository

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,7 +61,7 @@ class mongodb::params inherits mongodb::globals {
         $config       = '/etc/mongod.conf'
         $dbpath       = '/var/lib/mongodb'
         $logpath      = '/var/log/mongodb/mongodb.log'
-        $bind_ip      = ['127.0.0.1']
+        $bind_ip      = pick($bind_ip, ['127.0.0.1'])
       } else {
         # although we are living in a free world,
         # I would not recommend to use the prepacked


### PR DESCRIPTION
MongoDB servers installed on Debian systems from the 10gen/mongodb repository only listen on the loopback interface, even if the $bind_ip parameter is defined.

To reproduce:

``` puppet
class {'mongodb::globals':
  manage_package_repo => true,
  server_package_name => "mongodb-org-server", 
  version => '2.6.5',
  bind_ip => ['127.0.0.1', $::ipaddress],
} ->
class {'mongodb::server': }
```
