### PR TITLE
Fixed params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,6 +71,8 @@ class mongodb::params inherits mongodb::globals {
           $client_package_name = pick($::mongodb::globals::client_package_name, 'mongodb-org-shell')
           $package_ensure = true
           $package_ensure_client = true
+          $service_name = pick($::mongodb::globals::service_name, 'mongod')
+          $config = '/etc/mongod.conf'
         } else {
           # check if the version is greater than 2.6
           if(versioncmp($::mongodb::globals::version, '2.6.0') >= 0) {


### PR DESCRIPTION
There are two issues on Debian based distributions using
mongodb.org packages:

``` puppet
class {'::mongodb::globals':
manage_package_repo => true,
}->
class {'::mongodb::server':}->
class {'::mongodb::client':}
```
### $config is undef for mongodb config unter /etc

Error: Parameter path failed on File[undef]: File paths must be fully qualified, not 'undef' at /etc/puppet/modules/mongodb/manifests/server/config.pp:83
### $service_name is `mongodb` instead of `mongod`

Error: /Stage[main]/Mongodb::Server::Service/Service[mongodb]: Could not evaluate: Could not find init script or upstart conf file for 'mongodb'
Error: /Stage[main]/Mongodb::Server::Service/Service[mongodb]: Failed to call refresh: Could not find init script or upstart conf file for 'mongodb'
Error: /Stage[main]/Mongodb::Server::Service/Service[mongodb]: Could not find init script or upstart conf file for 'mongodb'
Warning: /Stage[main]/Mongodb::Server::Service/Mongodb_conn_validator[mongodb]: Skipping because of failed dependencies
Warning: /Stage[main]/Mongodb::Server/Anchor[mongodb::server::end]: Skipping because of failed dependencies
