### PR TITLE
Invalid JSON in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "10.04",
-        "12.04",
+        "12.04"
       ]
     }
   ],


### PR DESCRIPTION
This makes Librarian unhappy.

```
/home/stbenjam/.rvm/rubies/ruby-2.0.0-p576/lib/ruby/2.0.0/json/common.rb:155:in `parse': 399: unexpected token at '] (JSON::ParserError)
    }
  ],
  "dependencies": [
    {"name":"puppetlabs/apt","version_requirement":">= 1.0.0"},
    {"name":"puppetlabs/stdlib","version_requirement":">= 2.2.0"}
  ]
}
'
    from /home/stbenjam/.rvm/rubies/ruby-2.0.0-p576/lib/ruby/2.0.0/json/common.rb:155:in `parse'
```
