### PR TITLE
typo fix

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "10.04",
-        "12.04",
+        "12.04"
       ]
     }
   ],


### PR DESCRIPTION
The lack of trailing commas in json strikes again.
