### PR TITLE
Update Gemfile and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,17 @@
-branches:
-  only:
-    - master
+---
 language: ruby
-before_install:
-  - gem update bundler
-  - bundle --version
-  - gem update --system 2.1.11
-  - gem --version
-bundler_args: --without development
-script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
-after_success:
-  - git clone -q git://github.com/puppetlabs/ghpublisher.git .forge-release
-  - .forge-release/publish
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 2.7.0"
-    - PUPPET_GEM_VERSION="~> 3.3.0"
-  global:
-    - PUBLISHER_LOGIN=puppetlabs
-    - secure: "iUYpjvk33JffZB9lVRqjuwRWesvcvmTknh908xnf60rUOA0QbGEPXxQY+LsQJEIimVsMA22fV6vp9BcqMEjO7OfK2MvAWsEWU/lG+kisFqhWDRf96sADE7k/RvPWJeB2xe+lWXK7Eh26jgctNfk4NptX1X1MjGmdzEvH7Aq79/w="
+bundler_args: --without system_tests
+script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
-  exclude:
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
+  fast_finish: true
+  include:
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,30 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-group :test, :development do
-  gem 'rspec-puppet',            :require => false
+group :development, :unit_tests do
   gem 'rake',                    :require => false
+  gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'serverspec',              :require => false
   gem 'puppet-lint',             :require => false
-  gem 'pry',                     :require => false
   gem 'simplecov',               :require => false
-  gem 'beaker',                  :require => false
-  gem 'beaker-rspec',            :require => false
+  gem 'puppet_facts',            :require => false
+  gem 'json',                    :require => false
 end
 
-if puppetversion = ENV['PUPPET_VERSION']
+group :system_tests do
+  gem 'beaker-rspec',  :require => false
+  gem 'serverspec',    :require => false
+end
+
+if facterversion = ENV['FACTER_GEM_VERSION']
+  gem 'facter', facterversion, :require => false
+else
+  gem 'facter', :require => false
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', :require => false
 end
+
+# vim:ft=ruby

--- a/tests/replicaset.pp
+++ b/tests/replicaset.pp
@@ -7,9 +7,6 @@ node default {
     bind_ip    => ['0.0.0.0'],
     replset    => 'rsmain'
   }
-}
-
-node /mongo1/ inherits default {
   mongodb_replset{'rsmain':
     members => ['mongo1:27017', 'mongo2:27017', 'mongo3:27017']
   }


### PR DESCRIPTION
This change separates the gems for functional tests and unit tests so
that TravisCI doesn't have to care about beaker. It also brings the
Gemfile and .travis.yml files in line with the other puppetlabs modules.

Also fixed one of the test files to avoid deprecation warnings during the validate task.
