### PR TITLE
Fixed deprecated warnings from Apt::Source on debian

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -7,12 +7,16 @@ class mongodb::repo::apt inherits mongodb::repo {
 
   if($::mongodb::repo::ensure == 'present' or $::mongodb::repo::ensure == true) {
     apt::source { 'mongodb':
-      location    => $::mongodb::repo::location,
-      release     => 'dist',
-      repos       => '10gen',
-      key         => '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10',
-      key_server  => 'hkp://keyserver.ubuntu.com:80',
-      include_src => false,
+      location   => $::mongodb::repo::location,
+      release    => 'dist',
+      repos      => '10gen',
+      key        => {
+        'id'     => '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10',
+        'server' => 'hkp://keyserver.ubuntu.com:80',
+      },
+      include    => {
+        'src'    => false
+      }
     }
 
     Apt::Source['mongodb']->Package<|tag == 'mongodb'|>

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -7,15 +7,15 @@ class mongodb::repo::apt inherits mongodb::repo {
 
   if($::mongodb::repo::ensure == 'present' or $::mongodb::repo::ensure == true) {
     apt::source { 'mongodb':
-      location   => $::mongodb::repo::location,
-      release    => 'dist',
-      repos      => '10gen',
-      key        => {
+      location => $::mongodb::repo::location,
+      release  => 'dist',
+      repos    => '10gen',
+      key      => {
         'id'     => '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10',
         'server' => 'hkp://keyserver.ubuntu.com:80',
       },
-      include    => {
-        'src'    => false
+      include  => {
+        'src' => false
       }
     }
 


### PR DESCRIPTION
When using the puppetlabs-apt module, warnings were being issued about deprecated key syntax. Fixed this to use the new notation. 

Please let me know if you have any questions. Thanks! 

--Matt
