### PR TITLE
Explictly name shards in sh_addshard - allows for "standalone shards"

### DIFF
--- a/spec/unit/puppet/provider/mongodb_shard/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_shard/mongodb_spec.rb
@@ -53,7 +53,7 @@ describe Puppet::Type.type(:mongodb_shard).provider(:mongo) do
 
   describe '#create' do
     it 'makes a shard' do
-      provider.expects('sh_addshard').with("rs_test/mongo1:27018").returns(
+      provider.expects('sh_addshard').with("rs_test/mongo1:27018","rs_test").returns(
         { "shardAdded" => "rs_test",
           "ok" => 1 }
       )


### PR DESCRIPTION
Currently mongodb_shard will only work properly if the shards are replicasets (and the `mongodb_shard` resources are correctly named).  

The reason for this is that when adding a shard puppet calls `sh.addShard`.  This function lets MongoDB automatically assign the `_id` field to each shard.  If the shard is a replicaset the `_id` will be of the form `replset1/address:port`, however when the shard is a standalone mongodb server instance the `_id` will be something like `shard0001`.  When puppet agent runs and checks the status of mongo sharding it runs `sh.status()`, it looks for shards where the `_id` matches the `mongodb_shard` resource name, and if it doesn't find them it tries to add the shard again, which fails.

This fix explicitly sets the `_id` field for each shard according to the `mongodb_shard` resource name.

Seem reasonable? @Spredzy 
