### PR TITLE
Bugfix: the service does not start if it can't write its PID file

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -206,6 +206,12 @@ class mongodb::server::config {
       group   => $group,
       require => File[$config]
     }
+
+    file { $pidfilepath:
+      ensure  => present,
+      owner   => $user,
+      group   => $group,
+    }
   } else {
     file { $dbpath:
       ensure => absent,
@@ -214,6 +220,9 @@ class mongodb::server::config {
     }
     file { $config:
       ensure => absent
+    }
+    file { $pidfilepath:
+      ensure  => absent,
     }
   }
 


### PR DESCRIPTION
When installing the service using the upstream repository, it will not start because the `/var/run/` directory is not writable by the `mongodb` user (the upstream Debian packaging is not done the same way the distrib one is).
