### PR TITLE
added workaround to fix incompatible API for mongo<2.4 for password hash

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -135,7 +135,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     end
 
     if !out
-      raise Puppet::ExecutionFailure, "Could not evalute MongoDB shell command: #{cmd}"
+      raise Puppet::ExecutionFailure, "Could not evaluate MongoDB shell command: #{cmd}"
     end
 
     out.gsub!(/ObjectId\(([^)]*)\)/, '\1')

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -4,9 +4,32 @@ Puppet::Type.newtype(:mongodb_user) do
   ensurable
 
   def initialize(*args)
+
+    # required to create the password hash from plaintext
+    require 'digest/md5'
+
     super
     # Sort roles array before comparison.
     self[:roles] = Array(self[:roles]).sort!
+    if self[:ensure]
+      # password_has/password_plain check at initialization:
+      if self[:password_hash].nil?
+        if self[:password_plain].nil?
+          # if neither exist, fail
+          fail("Either 'password_hash' or 'password_plain' must be set. For mongodb > 2.4, hash is recommended. Use mongodb_password() for creating hash.")
+        else
+          # if only plaintext password exists, create the hash from the plain
+          self[:password_hash] = Digest::MD5.hexdigest(self[:username] + ":mongo:" + self[:password_plain])
+        end
+      else
+        unless self[:password_plain].nil?
+          # if both exist, both they don't correspond to each other, fail
+          if self[:password_hash] != Digest::MD5.hexdigest(self[:username] + ":mongo:" + self[:password_plain])
+            fail("if both 'password_hash' and 'password_plain' are specified, they must correspond.")
+          end
+        end
+      end
+    end
   end
 
   newparam(:name, :namevar=>true) do
@@ -16,6 +39,12 @@ Puppet::Type.newtype(:mongodb_user) do
   newproperty(:username) do
     desc "The name of the user."
     defaultto { @resource[:name] }
+  end
+
+  #represents a plaintext password (for mongodb <= 2.4)
+  #only a parameter, since there's no way to compare it with the current value
+  newparam(:password_plain) do
+    desc 'The password of the user in plaintext.'
   end
 
   newproperty(:database) do
@@ -52,9 +81,6 @@ Puppet::Type.newtype(:mongodb_user) do
 
   newproperty(:password_hash) do
     desc "The password hash of the user. Use mongodb_password() for creating hash."
-    defaultto do
-      fail("Property 'password_hash' must be set. Use mongodb_password() for creating hash.") if provider.database == :absent
-    end
     newvalue(/^\w+$/)
   end
 

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -6,7 +6,7 @@
 #
 #  user - Database username.
 #  password_hash - Hashed password. Hex encoded md5 hash of "$username:mongo:$password".
-#  password - Plain text user password. This is UNSAFE, use 'password_hash' unstead.
+#  password - Plain text user password. This is UNSAFE, use 'password_hash' instead.
 #  roles (default: ['dbAdmin']) - array with user roles.
 #  tries (default: 10) - The maximum amount of two second tries to wait MongoDB startup.
 #
@@ -32,12 +32,13 @@ define mongodb::db (
   }
 
   mongodb_user { "User ${user} on db ${name}":
-    ensure        => present,
-    password_hash => $hash,
-    username      => $user,
-    database      => $name,
-    roles         => $roles,
-    require       => Mongodb_database[$name],
+    ensure         => present,
+    username       => $user,
+    password_hash  => $hash,
+    password_plain => $password,
+    database       => $name,
+    roles          => $roles,
+    require        => Mongodb_database[$name],
   }
 
 }

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -6,19 +6,20 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   let(:raw_users) do
     [
-      { '_id' => 'admin.root', 'user' => 'root', 'db' => 'admin', 'credentials' => { 'MONGODB-CR' => 'pass' }, 'roles' => [ { 'role' => 'role2', 'db' => 'admin' },  { 'role' => 'role1', 'db' => 'admin' } ] }
+      { '_id' => 'admin.root', 'user' => 'root', 'db' => 'admin', 'credentials' => { 'MONGODB-CR' => '24fed24b83566e4d1f033f33f7caa658' }, 'roles' => [ { 'role' => 'role2', 'db' => 'admin' },  { 'role' => 'role1', 'db' => 'admin' } ] }
     ].to_json
   end
 
   let(:parsed_users) { %w(root) }
 
   let(:resource) { Puppet::Type.type(:mongodb_user).new(
-    { :ensure        => :present,
-      :name          => 'new_user',
-      :database      => 'new_database',
-      :password_hash => 'pass',
-      :roles         => ['role1', 'role2'],
-      :provider      => described_class.name
+    { :ensure         => :present,
+      :name           => 'new_user',
+      :database       => 'new_database',
+      :password_plain => 'pass',
+      :password_hash  => '24fed24b83566e4d1f033f33f7caa658', #must correspond to password_plain, or the provider complains
+      :roles          => ['role1', 'role2'],
+      :provider       => described_class.name
     }
   )}
 
@@ -55,7 +56,7 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
       cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
       {
         "createUser": "new_user",
-        "pwd": "pass",
+        "pwd": "24fed24b83566e4d1f033f33f7caa658",
         "customData": {"createdBy": "Puppet Mongodb_user['new_user']"},
         "roles": ["role1","role2"],
         "digestPassword": false
@@ -82,7 +83,7 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'password_hash' do
     it 'returns a password_hash' do
-      expect(instance.password_hash).to eq("pass")
+      expect(instance.password_hash).to eq("24fed24b83566e4d1f033f33f7caa658")
     end
   end
 
@@ -91,7 +92,7 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
       cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
       {
           "updateUser": "new_user",
-          "pwd": "pass",
+          "pwd": "24fed24b83566e4d1f033f33f7caa658",
           "digestPassword": false
       }
       EOS

--- a/spec/unit/puppet/type/mongodb_user_spec.rb
+++ b/spec/unit/puppet/type/mongodb_user_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Type.type(:mongodb_user) do
     @user = Puppet::Type.type(:mongodb_user).new(
               :name => 'test',
               :database => 'testdb',
-              :password_hash => 'pass')
+              :password_hash => '24fed24b83566e4d1f033f33f7caa658')
   end
 
   it 'should accept a user name' do
@@ -44,14 +44,8 @@ describe Puppet::Type.type(:mongodb_user) do
 
   it 'should require a database' do
     expect {
-      Puppet::Type.type(:mongodb_user).new({:name => 'test', :password_hash => 'pass'})
+      Puppet::Type.type(:mongodb_user).new({:name => 'test', :password_hash => '24fed24b83566e4d1f033f33f7caa658'})
     }.to raise_error(Puppet::Error, 'Parameter \'database\' must be set')
-  end
-
-  it 'should require a password_hash' do
-    expect {
-      Puppet::Type.type(:mongodb_user).new({:name => 'test', :database => 'testdb'})
-    }.to raise_error(Puppet::Error, 'Property \'password_hash\' must be set. Use mongodb_password() for creating hash.')
   end
 
   it 'should sort roles' do
@@ -59,7 +53,7 @@ describe Puppet::Type.type(:mongodb_user) do
     @user = Puppet::Type.type(:mongodb_user).new(
               :name => 'test',
               :database => 'testdb',
-              :password_hash => 'pass',
+              :password_hash => '24fed24b83566e4d1f033f33f7caa658',
               :roles => ['b', 'a'])
     expect(@user[:roles]).to eq(['a', 'b'])
   end


### PR DESCRIPTION
The mongodb API for versions <=2.4 has some differences regarding user management that until now were not considered by this puppet module.

To change a user password we need the command "db.changeUserPassword" and not "updateUser". On top of that, these older versions of mongo use plaintext passwords and don't allow hashes as input.

However, the API returns the password hash and not the plaintext password when user info is requested...

All this is covered by the changes introduced on this fork.
