### PR TITLE
fixes mongodb_user parameter in db.pp from 'username' to 'name'

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -34,7 +34,7 @@ define mongodb::db (
   mongodb_user { "User ${user} on db ${name}":
     ensure        => present,
     password_hash => $hash,
-    username      => $user,
+    name          => $user,
     database      => $name,
     roles         => $roles,
     require       => Mongodb_database[$name],


### PR DESCRIPTION
getting an error saing "username is an invalid parameter" when trying to create the admin user.  Found that mongo_user in db.pp was useing "username" parameter instead of "name" parameter.
