### PR TITLE
Allow the mongodb_user provider to accept roles for other databases in the format 'role@db' 	

### DIFF
--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -159,7 +159,7 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
           "#{entry['role']}@#{entry['db']}"
         end
       elsif entry.instance_of? String
-      if entry.end_with? "@#{db}"
+        if entry.end_with? "@#{db}"
           entry.gsub(/^(.*)@.*$/, '\1')
         else
           entry
@@ -173,30 +173,26 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
   end
   
   def role_hashes(roles, db)
-    roles.map do |entry|
+    roles.sort.map do |entry|
       if entry.instance_of? Hash and entry.has_key? 'role'
-        if entry.has_key? 'db'
-          entry
+        if entry['db'] == db
+          entry['role']
         else
-          { 
-            'role' => entry['role'], 
-            'db' => db 
-          }
+          entry
         end
       elsif entry.instance_of? String
-        if entry.include? '@'
+        if entry.end_with? "@#{db}"
+          entry.gsub(/^(.*)@.*$/, '\1')
+        elsif entry.include? '@'
           { 
             'role' => entry.gsub(/^(.*)@.*$/, '\1'),
             'db'   => entry.gsub(/^.*@(.*)$/, '\1'),
           }
         else
-          { 
-            'role' => entry['role'], 
-            'db' => db 
-          }
+          entry
         end
       end
-    end.sort
+    end
   end
   
 end

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -38,7 +38,7 @@ Puppet::Type.newtype(:mongodb_user) do
   newproperty(:roles, :array_matching => :all) do
     desc "The user's roles."
     defaultto ['dbAdmin']
-    newvalue(/^\w+$/)
+    newvalue(/^\w+@?\w+$/)
 
     # Pretty output for arrays.
     def should_to_s(value)

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -38,7 +38,7 @@ Puppet::Type.newtype(:mongodb_user) do
   newproperty(:roles, :array_matching => :all) do
     desc "The user's roles."
     defaultto ['dbAdmin']
-    newvalue(/^\w+@?\w+$/)
+    newvalue(/^\w+(@\w+)?$/)
 
     # Pretty output for arrays.
     def should_to_s(value)


### PR DESCRIPTION
The mongodb_user provider was previously only accepting an array of role-names for the database that the user is created on.  When comparing existing roles granted to that user with the ones on the mongodb_user resource, existing roles for other databases were being converted from the role/db hash to a string formatted like 'role@db'. Because these did not match any of the (non-db) resource roles, the provider attempted to revoke those roles, which failed because 'role@db' is not a valid role format in MongoDB.

This pull request alters the provider to accept roles in the role@db format. (where the @db part can be ommitted for roles on the user's own database).  When creating the user, or granting or revoking roles on an existing user, roles are converted to the valid role/db hash.  This allows the provider to successfully manage roles for multiple databases on the same user account.
