### PR TITLE
set correct permissions on dbpath

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -211,7 +211,7 @@ class mongodb::server::config {
 
     file { $dbpath:
       ensure   => directory,
-      mode     => '0755',
+      mode     => '0644',
       owner    => $user,
       group    => $group,
       recurse  => true,


### PR DESCRIPTION
Puppet will retain 0755 for directories.

I was getting restarts and primary/secondary switches on mongodb clusters on a very regular basis.
Since the file stanza is doing 'recurse', the mode set should be 0644. Mongodb was writing files with 0644, causing Puppet to change file mode triggering a restart (and a file shouldn't be 755 anyway).
Unless otherwise specified Puppet is smart enough to understand that when using 'recurse' directories should keep/get 755 - if you need other permissions for a directory in the tree those can be explicitly set with a separate entry.
