### PR TITLE
Set dbpath_fix to false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,12 @@ for your OS distro.
 Set this value to designate a directory for the mongod instance to store
 it's data. If not specified, the module will use the default for your OS distro.
 
+##### `dbpath_fix`
+Set this value to true if you want puppet to recursively manage the permissions
+of the files in the dbpath directory.  If you are using the default dbpath, this
+should probably be false. Set this to true if you are using a custom dbpath. The
+default is false.
+
 ##### `pidfilepath`
 Specify a file location to hold the PID or process ID of the mongod process.
 If not specified, the module will use the default for your OS distro.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class mongodb::params inherits mongodb::globals {
   $handle_creds          = true
   $store_creds           = false
   $rcfile                = "${::root_home}/.mongorc.js"
-  $dbpath_fix            = true
+  $dbpath_fix            = false
 
   $mongos_service_manage = pick($mongodb::globals::mongos_service_manage, true)
   $mongos_service_enable = pick($mongodb::globals::mongos_service_enable, true)


### PR DESCRIPTION
Under Xenial, the current default value of dbpath_fix set to true leads
to idempotency issues because the data files may be created with the
nogroup group.  This can lead to puppet repeatedly fixing permissions
which is not ideal. The files that are getting changed are set to 0600
so the group ownership does not help.  By default, we should be setting
this to false because we should not need to manage the user/group
permissions with the default install provided by distrobutions.