### PR TITLE
fix db_ismaster for mongo provider

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -36,8 +36,8 @@ Facter.add('mongodb_is_master') do
       Facter::Core::Execution.exec("mongo --quiet #{mongoPort} --eval \"#{e}printjson(db.adminCommand({ ping: 1 }))\"")
 
       if $?.success?
-        mongo_output = Facter::Core::Execution.exec("mongo --quiet #{mongoPort} --eval \"#{e}printjson(db.isMaster())\"")
-        JSON.parse(mongo_output.gsub(/\w+\(.+?\)/, '"foo"'))['ismaster'] ||= false
+        mongo_output = Facter::Core::Execution.exec("mongo --quiet #{mongoPort} --eval \"#{e}db.isMaster().ismaster\"").to_s.strip
+        mongo_output.eql?('true') ? true : false
       else
         'not_responding'
       end

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -135,7 +135,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       cmd_ismaster = mongorc_file + cmd_ismaster
     end
     db = 'admin'
-    res = mongo_eval(cmd_ismaster).to_s.gsub(/\n/, '').chomp()
+    res = mongo_eval(cmd_ismaster).to_s.strip
     res.eql?('true') ? true : false
   end
 

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -135,7 +135,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       cmd_ismaster = mongorc_file + cmd_ismaster
     end
     db = 'admin'
-    res = mongo_cmd(db, get_conn_string, cmd_ismaster).to_s.chomp()
+    res = mongo_eval(cmd_ismaster).to_s.gsub(/\n/, '').chomp()
     res.eql?('true') ? true : false
   end
 


### PR DESCRIPTION

This solves the error on replicat set when admin user not set.

when the auth failed, mongo-shell return a error, not only true or false :
`# mongo --quiet --eval "load('/root/.mongorc.js'); db.isMaster().ismaster"
Error: Authentication failed.
true`
