### PR TITLE
Fix constant refresh of Service[mongodb].

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -232,7 +232,7 @@ class mongodb::server::config {
       exec { 'fix dbpath permissions':
         command   => "chown -R ${user}:${group} ${dbpath}",
         path      => ['/usr/bin', '/bin'],
-        onlyif    => "find ${dbpath} -not -user ${user} -o -not -group ${group} -print -quit | grep -q '.*'",
+        onlyif    => "find ${dbpath} -path ${dbpath}/journal -prune -not -user ${user} -o -not -group ${group} -print -quit | grep -q '.*'",
         subscribe => File[$dbpath]
       }
     }


### PR DESCRIPTION
On Ubuntu 14.04.5 LTS `Service['mongodb']` is restarted with every puppet run because the journal files in `/var/lib/mongodb/journal` are of group `nogroup`.  This results in `Exec['fix dbpath permissions']`'s `onlyif` matching and refreshing `Service['mongodb']` which in turn changes the group back to `nogroup`.  This repeats endlessly.
Here I simply ignore the ownership of `"${dbpath}/journal"`, which should be safe because it won't be created during install and instead have whatever permissions the MongoDB daemon "wants" them to have.