### PR TITLE
Allow user-supplied configuration data

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ class mongodb::server {
 ```
 
 ##### `config_data`
-A hash to allow for additional configuration options 
+A hash to allow for additional configuration options
 to be set in user-provided template.
 
 

--- a/README.md
+++ b/README.md
@@ -426,11 +426,6 @@ Mutually exclusive with `replset_config` param.
 A hash that is used to configure the replica set.
 Mutually exclusive with `replset_members` param.
 
-##### `config_data`
-A hash to allow for additional configuration options 
-to be set in user-provided template.
-
-
 ```puppet
 class mongodb::server {
   replset        => 'rsmain',
@@ -438,6 +433,11 @@ class mongodb::server {
 
 }
 ```
+
+##### `config_data`
+A hash to allow for additional configuration options 
+to be set in user-provided template.
+
 
 ##### `rest`
 Set to true to enable a simple REST interface. Default: false

--- a/README.md
+++ b/README.md
@@ -426,6 +426,11 @@ Mutually exclusive with `replset_config` param.
 A hash that is used to configure the replica set.
 Mutually exclusive with `replset_members` param.
 
+##### `config_data`
+A hash to allow for additional configuration options 
+to be set in user-provided template.
+
+
 ```puppet
 class mongodb::server {
   replset        => 'rsmain',
@@ -558,6 +563,9 @@ Config content if the default doesn't match one needs.
 
 ##### `config_template`
 Path to the config template if the default doesn't match one needs.
+
+##### `config_data`
+Hash containing key-value pairs to allow for additional configuration options to be set in user-provided template.
 
 ##### `configdb`
 Array of the config servers IP addresses the mongos should connect to.

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -5,6 +5,7 @@ class mongodb::mongos (
   $config_content   = undef,
   $config_template  = undef,
   $configdb         = $mongodb::params::mongos_configdb,
+  $config_data      = $mongodb::params::config_data,
   $service_manage   = $mongodb::params::mongos_service_manage,
   $service_provider = undef,
   $service_name     = $mongodb::params::mongos_service_name,

--- a/manifests/mongos/config.pp
+++ b/manifests/mongos/config.pp
@@ -5,6 +5,7 @@ class mongodb::mongos::config (
   $config_content  = $mongodb::mongos::config_content,
   $config_template = $mongodb::mongos::config_template,
   $configdb        = $mongodb::mongos::configdb,
+  $config_data     = $mongodb::mongos::config_data,
 ) {
 
   if ($ensure == 'present' or $ensure == true) {
@@ -13,8 +14,10 @@ class mongodb::mongos::config (
     if $config_content {
       $config_content_real = $config_content
     } elsif $config_template {
+      # Template has $config_data hash available
       $config_content_real = template($config_template)
     } else {
+      # Template has $config_data hash available
       $config_content_real = template('mongodb/mongodb-shard.conf.erb')
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,8 @@ class mongodb::params inherits mongodb::globals {
 
   $version = $::mongodb::globals::version
 
+  $config_data           = undef
+
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $::osfamily {
     'RedHat', 'Linux', 'Suse': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -69,6 +69,7 @@ class mongodb::server (
   $syslog                = undef,
   $config_content        = undef,
   $config_template       = undef,
+  $config_data           = undef,
   $ssl                   = undef,
   $ssl_key               = undef,
   $ssl_ca                = undef,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -6,6 +6,7 @@ class mongodb::server::config {
   $config           = $mongodb::server::config
   $config_content   = $mongodb::server::config_content
   $config_template  = $mongodb::server::config_template
+  $config_data      = $mongodb::server::config_data
   $dbpath           = $mongodb::server::dbpath
   $dbpath_fix       = $mongodb::server::dbpath_fix
   $pidfilepath      = $mongodb::server::pidfilepath
@@ -109,6 +110,8 @@ class mongodb::server::config {
     if $config_content {
       $cfg_content = $config_content
     } elsif $config_template {
+      # Template has available user-supplied data
+      # - $config_data
       $cfg_content = template($config_template)
     } elsif $version and (versioncmp($version, '2.6.0') >= 0) {
       # Template uses:
@@ -152,6 +155,9 @@ class mongodb::server::config {
       # - $system_logrotate
       # - $verbose
       # - $verbositylevel
+
+      # Template has available user-supplied data
+      # - $config_data
       $cfg_content = template('mongodb/mongodb.conf.2.6.erb')
     } else {
       # Fall back to oldest most basic config
@@ -209,6 +215,8 @@ class mongodb::server::config {
       # - $syslog
       # - $verbose
       # - $verbositylevel
+      # Template has available user-supplied data
+      # - $config_data
       $cfg_content = template('mongodb/mongodb.conf.erb')
     }
 

--- a/templates/mongodb-shard.conf.erb
+++ b/templates/mongodb-shard.conf.erb
@@ -19,3 +19,9 @@ logpath = <%= @logpath %>
 <% if @unixsocketprefix -%>
 unixSocketPrefix = <%= @unixsocketprefix %>
 <% end -%>
+
+<% if @config_data -%>
+<% @config_data.each do |k,v| -%>
+<%= k %>: <%= v %>
+<% end -%>
+<% end -%>

--- a/templates/mongodb-shard.conf.erb
+++ b/templates/mongodb-shard.conf.erb
@@ -22,6 +22,6 @@ unixSocketPrefix = <%= @unixsocketprefix %>
 
 <% if @config_data -%>
 <% @config_data.each do |k,v| -%>
-<%= k %>: <%= v %>
+<%= k %> = <%= v %>
 <% end -%>
 <% end -%>

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -154,3 +154,9 @@ operationProfiling.slowOpThresholdMs: <%= @slowms %>
 <% if @set_parameter -%>
 setParameter: <%= @set_parameter %>
 <% end -%>
+
+<% if @config_data -%>
+<% @config_data.each do |k,v| -%>
+<%= k %>: <%= v %>
+<% end -%>
+<% end -%>

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -200,3 +200,9 @@ sslWeakCertificateValidation = <%= @ssl_weak_cert %>
 net.ssl.allowInvalidHostnames = <%= @ssl_invalid_hostnames %>
 <% end -%>
 <% end -%>
+
+<% if @config_data -%>
+<% @config_data.each do |k,v| -%>
+<%= k %>: <%= v %>
+<% end -%>
+<% end -%>

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -203,6 +203,6 @@ net.ssl.allowInvalidHostnames = <%= @ssl_invalid_hostnames %>
 
 <% if @config_data -%>
 <% @config_data.each do |k,v| -%>
-<%= k %>: <%= v %>
+<%= k %> = <%= v %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Added support to provide a hash containing user-supplied key/value pairs for use with configuration templates. 

Support added for mongodb::server and mongodb::mongos classes.