### PR TITLE
Yum repo references a non-existent mongo::repo::description field

### DIFF
--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -5,7 +5,6 @@ class mongodb::repo::yum inherits mongodb::repo {
 
   if($::mongodb::repo::ensure == 'present' or $::mongodb::repo::ensure == true) {
     yumrepo { 'mongodb':
-      descr          => $::mongodb::repo::description,
       baseurl        => $::mongodb::repo::location,
       gpgcheck       => '0',
       enabled        => '1',


### PR DESCRIPTION
The description field doesn't exist in the base class. Since this is a trivial system, ignore it for this system