### PR TITLE
Fix for MODULES-5560

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -14,8 +14,8 @@
 define mongodb::db (
   $user,
   $db_name       = $name,
-  $password_hash = false,
-  $password      = false,
+  $password_hash = undef,
+  $password      = undef,
   $roles         = ['dbAdmin'],
   $tries         = 10,
 ) {
@@ -35,8 +35,7 @@ define mongodb::db (
 
   mongodb_user { "User ${user} on db ${db_name}":
     ensure        => present,
-    password_hash => $password_hash,
-    password      => $password,
+    password_hash => $hash,
     username      => $user,
     database      => $db_name,
     roles         => $roles,

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -5,7 +5,6 @@ class mongodb::repo::yum inherits mongodb::repo {
 
   if($::mongodb::repo::ensure == 'present' or $::mongodb::repo::ensure == true) {
     yumrepo { 'mongodb':
-      descr          => $::mongodb::repo::description,
       baseurl        => $::mongodb::repo::location,
       gpgcheck       => '0',
       enabled        => '1',


### PR DESCRIPTION
Two parametrs should be defined as undef, not false.

mongodb_user should only use the previously constructed $hash parameter, and not the class parameters.