### PR TITLE
Fix password on admin db

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -35,8 +35,7 @@ define mongodb::db (
 
   mongodb_user { "User ${user} on db ${db_name}":
     ensure        => present,
-    password_hash => $password_hash,
-    password      => $password,
+    password_hash => $hash,
     username      => $user,
     database      => $db_name,
     roles         => $roles,


### PR DESCRIPTION
Looks liek the mongo_user definition changed to only accept password_hash and this wasnt updated for creating the admin database.

Correct pass the password_hash parameter as $hash variable.