### PR TITLE
Fixing some issues for mongodb 3.4

### DIFF
--- a/lib/facter/mongodb_version.rb
+++ b/lib/facter/mongodb_version.rb
@@ -2,7 +2,7 @@ Facter.add(:mongodb_version) do
   setcode do
     if Facter::Core::Execution.which('mongo')
       mongodb_version = Facter::Core::Execution.execute('mongo --version 2>&1')
-      %r{^MongoDB shell version:?\s+([\w\.]+)}.match(mongodb_version)[1]
+      %r{^MongoDB shell version(: | v)([\w\.]+)}.match(mongodb_version)[2]
     end
   end
 end

--- a/lib/facter/mongodb_version.rb
+++ b/lib/facter/mongodb_version.rb
@@ -2,7 +2,7 @@ Facter.add(:mongodb_version) do
   setcode do
     if Facter::Core::Execution.which('mongo')
       mongodb_version = Facter::Core::Execution.execute('mongo --version 2>&1')
-      %r{^MongoDB shell version(: | v)([\w\.]+)}.match(mongodb_version)[2]
+      %r{^MongoDB shell version:?\s+([\w\.]+)}.match(mongodb_version)[1]
     end
   end
 end

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -135,7 +135,8 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     cmd_ismaster = mongorc_file + cmd_ismaster if mongorc_file
     db = 'admin'
     res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
-    res.eql?('true') ? true : false
+    res.gsub!(%r{^.*The server certificate does not match the host name.+}, '') # remove warnings if sslAllowInvalidHostnames is true mongo 3.x
+    res.strip.eql?('true') ? true : false
   end
 
   def db_ismaster

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -27,7 +27,12 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
         end
         return allusers
       else
-        users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())')
+        # This can fail in 3.x before the admin user is created.
+        begin
+          users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())')
+        rescue Puppet::ExecutionFailure
+          users = []
+        end
 
         users.map do |user|
           new(name: user['_id'],

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -100,14 +100,16 @@ class mongodb::server (
   }
 
   if $create_admin and ($service_ensure == 'running' or $service_ensure == true) {
-    mongodb::db { 'admin':
-      user     => $admin_username,
-      password => $admin_password,
-      roles    => $admin_roles,
+    mongodb_user { $admin_username:
+      ensure        => present,
+      password_hash => mongodb_password($admin_username, $admin_password),
+      roles         => $admin_roles,
+      database      => 'admin',
     }
 
     # Make sure it runs before other DB creation
-    Mongodb::Db['admin'] -> Mongodb::Db <| title != 'admin' |>
+    Mongodb_user[$admin_username] -> Mongodb::Db <| title != $admin_username |>
+    Mongodb_user[$admin_username] -> Mongodb_user <| title != $admin_username |>
   }
 
   # Set-up replicasets
@@ -142,7 +144,7 @@ class mongodb::server (
 
       # Make sure that the ordering is correct
       if $create_admin {
-        Class['mongodb::replset'] -> Mongodb::Db['admin']
+        Class['mongodb::replset'] -> Mongodb_user['admin']
       }
 
     }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -16,6 +16,14 @@ describe 'mongodb::server' do
             that_notifies('Class[mongodb::server::service]')
         }
         it { is_expected.to contain_class('mongodb::server::service') }
+        it {
+          is_expected.to contain_mongodb_user('admin').with('user' => 'admin',
+                                                           'password_hash' => '90f500568434c37b61c8c1ce05fdf3ae',
+                                                           'roles'    => %w[userAdmin readWrite dbAdmin dbAdminAnyDatabase
+                                                                            readAnyDatabase readWriteAnyDatabase userAdminAnyDatabase
+                                                                            clusterAdmin clusterManager clusterMonitor hostManager
+                                                                            root restore])
+        }
       end
 
       describe 'with manage_package => true' do


### PR DESCRIPTION
I realized that even though $mongodb::server::version is used in mongodb::server::config, it is not set. So setting it to the version in the fact mongodb_version. This fixes the configuration (format) for mongodb 3.4.
Additionally I merged some changes out of pull request #351

Unfortunately I could not find a way to create a cluster with auth enabled. So any idea for that would be welcome.