### PR TITLE
rebased PR#308 to allow other databases in the format 'role@db' for mongodb_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,10 @@ For more information please refer to [MongoDB Authentication Process](http://doc
 Plain-text user password (will be hashed)
 
 ##### `roles`
-Array with user roles. Default: ['dbAdmin']
+Array with user roles as string.
+Roles will be granted to user's database if no alternative database is explicitly defined.
+Example: ['dbAdmin', 'readWrite@other_database']
+Default: ['dbAdmin']
 
 ### Providers
 
@@ -697,7 +700,10 @@ Plaintext password of the user.
 Name of database. It will be created, if not exists.
 
 ##### `roles`
-Array with user roles. Default: ['dbAdmin']
+Array with user roles as string.
+Roles will be granted to user's database if no alternative database is explicitly defined.
+Example: ['dbAdmin', 'readWrite@other_database']
+Default: ['dbAdmin']
 
 ##### `tries`
 The maximum amount of two second tries to wait MongoDB startup. Default: 10

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -40,7 +40,7 @@ Puppet::Type.newtype(:mongodb_user) do
   newproperty(:roles, array_matching: :all) do
     desc "The user's roles."
     defaultto ['dbAdmin']
-    newvalue(%r{^\w+$})
+    newvalue(%r{^\w+(@\w+)?$})
 
     # Pretty output for arrays.
     def should_to_s(value)

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -50,4 +50,82 @@ describe 'mongodb_database' do
       end
     end
   end
+
+  context 'with the basic roles syntax' do
+    it 'compiles with no errors' do
+      pp = <<-EOS
+        class { 'mongodb::server': }
+        -> class { 'mongodb::client': }
+        -> mongodb_database { 'testdb': ensure => present }
+        ->
+        mongodb_user {'testuser':
+          ensure        => present,
+          password_hash => mongodb_password('testuser', 'passw0rd'),
+          database      => 'testdb',
+          roles         => ['readWrite', 'dbAdmin'],
+        }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'creates the user' do
+      shell("mongo testdb --quiet --eval 'db.auth(\"testuser\",\"passw0rd\")'") do |r|
+        expect(r.stdout.chomp).to eq('1')
+      end
+    end
+  end
+
+  context 'with the new multidb role syntax' do
+    it 'compiles with no errors' do
+      pp = <<-EOS
+        class { 'mongodb::server': }
+        -> class { 'mongodb::client': }
+        -> mongodb_database { 'testdb': ensure => present }
+        -> mongodb_database { 'testdb2': ensure => present }
+        ->
+        mongodb_user {'testuser':
+          ensure        => present,
+          password_hash => mongodb_password('testuser', 'passw0rd'),
+          database      => 'testdb',
+          roles         => ['readWrite', 'dbAdmin'],
+        }
+        ->
+        mongodb_user {'testuser2':
+          ensure        => present,
+          password_hash => mongodb_password('testuser2', 'passw0rd'),
+          database      => 'testdb2',
+          roles         => ['readWrite', 'dbAdmin', 'readWrite@testdb', 'dbAdmin@testdb'],
+        }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'allows the testuser' do
+      shell("mongo testdb --quiet --eval 'db.auth(\"testuser\",\"passw0rd\")'") do |r|
+        expect(r.stdout.chomp).to eq('1')
+      end
+    end
+
+    it 'assigns roles to testuser' do
+      shell("mongo testdb --quiet --eval 'db.auth(\"testuser\",\"passw0rd\"); db.getUser(\"testuser\")[\"roles\"].forEach(function(role){print(role.role + \"@\" + role.db)})'") do |r|
+        expect(r.stdout.split(%r{\n})).to contain_exactly('readWrite@testdb', 'dbAdmin@testdb')
+      end
+    end
+
+    it 'allows the second user to connect to its default database' do
+      shell("mongo testdb2 --quiet --eval 'db.auth(\"testuser2\",\"passw0rd\")'") do |r|
+        expect(r.stdout.chomp).to eq('1')
+      end
+    end
+
+    it 'assigns roles to testuser2' do
+      shell("mongo testdb2 --quiet --eval 'db.auth(\"testuser2\",\"passw0rd\"); db.getUser(\"testuser2\")[\"roles\"].forEach(function(role){print(role.role + \"@\" + role.db)})'") do |r|
+        expect(r.stdout.split(%r{\n})).to contain_exactly('readWrite@testdb2', 'dbAdmin@testdb2', 'readWrite@testdb', 'dbAdmin@testdb')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Rebased an squashed @sharon-tickell changes to allow the mongodb_user provider to accept roles for other databases in the format 'role@db' from pull request #308.
I was able to grant roles using the old (<role>) and the new format (<role>@<db>).