### PR TITLE
Add a retry block when hosts are added to replset

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -245,12 +245,12 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
         retry_limit.times do |n|
           begin
             output = rs_arbiter == host ? rs_add_arbiter(host, master) : rs_add(host, master)
-	    if !output['ok'].zero?
-              Puppet.debug "Host successfully added to replicaset"
-	      break
-	    else
-	      Puppet.debug "Retry adding host to replicaset. Retry: #{n}"
-	      sleep retry_sleep
+            if !output['ok'].zero?
+              Puppet.debug 'Host successfully added to replicaset'
+              break
+            else
+              Puppet.debug "Retry adding host to replicaset. Retry: #{n}"
+              sleep retry_sleep
               master = master_host(alive_hosts)
               next
             end

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -243,17 +243,14 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
 
         output = {}
         retry_limit.times do |n|
-          begin
-            output = rs_arbiter == host ? rs_add_arbiter(host, master) : rs_add(host, master)
-            if !output['ok'].zero?
-              Puppet.debug 'Host successfully added to replicaset'
-              break
-            else
-              Puppet.debug "Retry adding host to replicaset. Retry: #{n}"
-              sleep retry_sleep
-              master = master_host(alive_hosts)
-              next
-            end
+          output = rs_arbiter == host ? rs_add_arbiter(host, master) : rs_add(host, master)
+          if !output['ok'].zero?
+            Puppet.debug 'Host successfully added to replicaset'
+            break
+          else
+            Puppet.debug "Retry adding host to replicaset. Retry: #{n}"
+            sleep retry_sleep
+            master = master_host(alive_hosts)
           end
         end
         raise Puppet::Error, "rs.add() failed to add host to replicaset #{name}: #{output['errmsg']}" if output['ok'].zero?

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -238,8 +238,24 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
       Puppet.debug "New Hosts are: #{newhosts.inspect}"
 
       newhosts.each do |host|
+        retry_limit = 10
+        retry_sleep = 3
+
         output = {}
-        output = rs_arbiter == host ? rs_add_arbiter(host, master) : rs_add(host, master)
+        retry_limit.times do |n|
+          begin
+            output = rs_arbiter == host ? rs_add_arbiter(host, master) : rs_add(host, master)
+	    if !output['ok'].zero?
+              Puppet.debug "Host successfully added to replicaset"
+	      break
+	    else
+	      Puppet.debug "Retry adding host to replicaset. Retry: #{n}"
+	      sleep retry_sleep
+              master = master_host(alive_hosts)
+              next
+            end
+          end
+        end
         raise Puppet::Error, "rs.add() failed to add host to replicaset #{name}: #{output['errmsg']}" if output['ok'].zero?
       end
     end


### PR DESCRIPTION
There is a race condition here where, if the master has changed since
the replset host add will fail. This can happen when scaling out of nodes
or when master is being migrated.

Adding a retry block here will give the hosts a chance to join the
cluster while the master is coming up.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
