### PR TITLE
add rs.slaveOk to run before the getDBs call

### DIFF
--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
 
   def self.instances
     require 'json'
-    dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs())')
+    dbs = JSON.parse mongo_eval('rs.slaveOk();printjson(db.getMongo().getDBs())')
 
     dbs['databases'].map do |db|
       new(name: db['name'],

--- a/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
@@ -38,7 +38,7 @@ describe Puppet::Type.type(:mongodb_database).provider(:mongodb) do
     tmp = Tempfile.new('test')
     mongodconffile = tmp.path
     allow(provider.class).to receive(:mongod_conf_file).and_return(mongodconffile)
-    provider.class.stubs(:mongo_eval).with('printjson(db.getMongo().getDBs())').returns(raw_dbs)
+    provider.class.stubs(:mongo_eval).with('rs.slaveOk();printjson(db.getMongo().getDBs())').returns(raw_dbs)
     allow(provider.class).to receive(:db_ismaster).and_return(true)
   end
 


### PR DESCRIPTION
otherwise puppet runs fail on the slaves in a multi node replica mongo setup.
how this occurs from what I've been able to see:

provision 3 vm's:
* on the first vm the puppet runs succeeds, installing and configuring a mongodb with a replicaset and defining and setting up the required databases on that node. this node becomes the master.
* on the second vm during the puppet runs, puppet fetches a list of databases on the current mongo (replicaset),which returns the error: 

> Failed to apply catalog: Could not evaluate MongoDB shell command: printjson(db.getMongo().getDBs())

 * the same occurs on the 3rd node, since this is a slave as well.

to fix this we must pass the rs.slaveOk() command before the printjson(db.getMongo().getDBs()), in order to allow the current connection to allow read operations to run on secondary members.
which I hope to solve with this pull request, if there are cleaner/better ways to fix this issue, I'm open to suggestions.
