### PR TITLE
Bump stdlib 4.4.0->4.13.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.4.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
puppet-mongodb uses at least Stdlib::Absolutepath that has been introduced in puppetlabs-stdlib version 4.13.0.
