### PR TITLE
Add check if scram credentials are insync with hash

### DIFF
--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -35,7 +35,8 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
               username: user['user'],
               database: user['db'],
               roles: from_roles(user['roles'], user['db']),
-              password_hash: user['credentials']['MONGODB-CR'])
+              password_hash: user['credentials']['MONGODB-CR'],
+              scram_credentials: user['credentials']['SCRAM-SHA-1'])
         end
       end
     else

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -116,8 +116,8 @@ Puppet::Type.newtype(:mongodb_user) do
     elsif !self[:password_hash].nil? && !self[:password].nil?
       err("Only one of 'password_hash' or 'password' should be provided")
     end
-    if self.should(:scram_credentials)
-      self.fail("The parameter 'scram_credentials' is read-only and cannot be changed")
+    if should(:scram_credentials)
+      raise("The parameter 'scram_credentials' is read-only and cannot be changed")
     end
   end
 end

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -1,4 +1,5 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'util', 'mongodb_md5er'))
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'util', 'mongodb_scram'))
 Puppet::Type.newtype(:mongodb_user) do
   @doc = 'Manage a MongoDB user. This includes management of users password as well as privileges.'
 
@@ -59,6 +60,19 @@ Puppet::Type.newtype(:mongodb_user) do
       end
     end
     newvalue(%r{^\w+$})
+
+    def insync?(is)
+      # check if computed keys from password_hash, salt and iterations
+      # match the keys of the existing user
+      if is == :absent && @resource.provider.scram_credentials
+        scram = @resource.provider.scram_credentials
+        scram_util = Puppet::Util::MongodbScram.new(should, scram['salt'], scram['iterationCount'])
+        if scram['storedKey'] == scram_util.stored_key && scram['serverKey'] == scram_util.server_key
+          is = should
+        end
+      end
+      should == is
+    end
   end
 
   newproperty(:password) do
@@ -80,6 +94,10 @@ Puppet::Type.newtype(:mongodb_user) do
     end
   end
 
+  newproperty(:scram_credentials) do
+    desc 'The SCRAM-SHA-1 credentials of a user. These are read only and change when password or password_hash changes.'
+  end
+
   autorequire(:package) do
     'mongodb_client'
   end
@@ -97,6 +115,9 @@ Puppet::Type.newtype(:mongodb_user) do
       err("Either 'password_hash' or 'password' should be provided")
     elsif !self[:password_hash].nil? && !self[:password].nil?
       err("Only one of 'password_hash' or 'password' should be provided")
+    end
+    if self.should(:scram_credentials)
+      self.fail("The parameter 'scram_credentials' is read-only and cannot be changed")
     end
   end
 end

--- a/lib/puppet/util/mongodb_scram.rb
+++ b/lib/puppet/util/mongodb_scram.rb
@@ -1,0 +1,54 @@
+require 'securerandom'
+require 'base64'
+
+module Puppet
+  module Util
+    class MongodbScram
+      CLIENT_KEY = 'Client Key'.freeze
+      SERVER_KEY = 'Server Key'.freeze
+
+      attr_reader :password_hash
+      attr_reader :salt
+      attr_reader :iterations
+
+      def initialize(password_hash, salt, iterations)
+        @password_hash = password_hash
+        @salt = salt
+        @iterations = iterations
+      end
+
+      def digest
+        @digest ||= OpenSSL::Digest::SHA1.new.freeze
+      end
+
+      def hash(string)
+        digest.digest(string)
+      end
+
+      def hmac(data, key)
+        OpenSSL::HMAC.digest(digest, data, key)
+      end
+
+      def salted_password
+        OpenSSL::PKCS5.pbkdf2_hmac_sha1(
+          @password_hash,
+          Base64.strict_decode64(@salt),
+          @iterations,
+          digest.size
+        )
+      end
+
+      def client_key
+        hmac(salted_password, CLIENT_KEY)
+      end
+
+      def stored_key
+        Base64.strict_encode64(hash(client_key))
+      end
+
+      def server_key
+        Base64.strict_encode64(hmac(salted_password, SERVER_KEY))
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -5,7 +5,7 @@ require 'tempfile'
 describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
   let(:raw_users) do
     [
-      { '_id' => 'admin.root', 'user' => 'root', 'db' => 'admin', 'credentials' => { 'MONGODB-CR' => 'pass', 'SCRAM-SHA-1' => { 'iterationCount' => _10000, 'salt' => 'salt', 'storedKey' => 'storedKey', 'serverKey' => 'serverKey' } }, 'roles' => [{ 'role' => 'role2', 'db' => 'admin' }, { 'role' => 'role1', 'db' => 'admin' }] }
+      { '_id' => 'admin.root', 'user' => 'root', 'db' => 'admin', 'credentials' => { 'MONGODB-CR' => 'pass', 'SCRAM-SHA-1' => { 'iterationCount' => 10_000, 'salt' => 'salt', 'storedKey' => 'storedKey', 'serverKey' => 'serverKey' } }, 'roles' => [{ 'role' => 'role2', 'db' => 'admin' }, { 'role' => 'role1', 'db' => 'admin' }] }
     ].to_json
   end
 
@@ -103,7 +103,7 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
   describe 'scram_credentials' do
     it 'returns scram_credentials' do
       credentials = {
-        'iterationCount' => _10000,
+        'iterationCount' => 10_000,
         'salt' => 'salt',
         'storedKey' => 'storedKey',
         'serverKey' => 'serverKey'

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -5,7 +5,7 @@ require 'tempfile'
 describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
   let(:raw_users) do
     [
-      { '_id' => 'admin.root', 'user' => 'root', 'db' => 'admin', 'credentials' => { 'MONGODB-CR' => 'pass' }, 'roles' => [{ 'role' => 'role2', 'db' => 'admin' }, { 'role' => 'role1', 'db' => 'admin' }] }
+      { '_id' => 'admin.root', 'user' => 'root', 'db' => 'admin', 'credentials' => { 'MONGODB-CR' => 'pass', 'SCRAM-SHA-1' => { 'iterationCount' => 10000, 'salt' => 'salt', 'storedKey' => 'storedKey', 'serverKey' => 'serverKey' } }, 'roles' => [{ 'role' => 'role2', 'db' => 'admin' }, { 'role' => 'role1', 'db' => 'admin' }] }
     ].to_json
   end
 
@@ -97,6 +97,18 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
       provider.expects(:mongo_eval).
         with("db.runCommand(#{cmd_json})", 'new_database')
       provider.password_hash = 'newpass'
+    end
+  end
+
+  describe 'scram_credentials' do
+    it 'returns scram_credentials' do
+      credentials = {
+        'iterationCount' => 10000,
+        'salt' => 'salt',
+        'storedKey' => 'storedKey',
+        'serverKey' => 'serverKey'
+      }
+      expect(instance.scram_credentials).to match(credentials)
     end
   end
 

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -5,7 +5,7 @@ require 'tempfile'
 describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
   let(:raw_users) do
     [
-      { '_id' => 'admin.root', 'user' => 'root', 'db' => 'admin', 'credentials' => { 'MONGODB-CR' => 'pass', 'SCRAM-SHA-1' => { 'iterationCount' => 10000, 'salt' => 'salt', 'storedKey' => 'storedKey', 'serverKey' => 'serverKey' } }, 'roles' => [{ 'role' => 'role2', 'db' => 'admin' }, { 'role' => 'role1', 'db' => 'admin' }] }
+      { '_id' => 'admin.root', 'user' => 'root', 'db' => 'admin', 'credentials' => { 'MONGODB-CR' => 'pass', 'SCRAM-SHA-1' => { 'iterationCount' => _10000, 'salt' => 'salt', 'storedKey' => 'storedKey', 'serverKey' => 'serverKey' } }, 'roles' => [{ 'role' => 'role2', 'db' => 'admin' }, { 'role' => 'role1', 'db' => 'admin' }] }
     ].to_json
   end
 
@@ -103,7 +103,7 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
   describe 'scram_credentials' do
     it 'returns scram_credentials' do
       credentials = {
-        'iterationCount' => 10000,
+        'iterationCount' => _10000,
         'salt' => 'salt',
         'storedKey' => 'storedKey',
         'serverKey' => 'serverKey'


### PR DESCRIPTION
#### Pull Request (PR) description
For mongodb >3 the auth mechanism SCRAM-SHA-1 is the new default.
This adds a util and check if the keys computed by password_hash,
salt and iterationCount matches the keys of the existing user.

How SCRAM-SHA-1 works is described here: https://www.mongodb.com/blog/post/improved-password-based-authentication-mongodb-30-scram-explained-part-1

The test I have added is really basic, please let me know if and how this could be improved. Also the scram_credentials parameter is "read-only" which is just done via validate. Looking at other types in the puppet source this is usually how they are dealt with.

#### This Pull Request (PR) fixes the following issues
Fixes #425 