### PR TITLE
Handle non-existing config file

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -10,49 +10,57 @@ def mongod_conf_file
   file
 end
 
+def get_options_from_hash_config(config)
+  result = []
+
+  result << "--port #{config['net.port']}" unless config['net.port'].nil?
+  result << "--ssl --host #{Facter.value(:fqdn)}" if config['net.ssl.mode'] == 'requireSSL'
+  result << "--sslPEMKeyFile #{config['net.ssl.PEMKeyFile']}" unless config['net.ssl.PEMKeyFile'].nil?
+  result << "--sslCAFile #{config['net.ssl.CAFile']}" unless config['net.ssl.CAFile'].nil?
+  result << '--ipv6' unless config['net.ipv6'].nil?
+
+  result.join(' ')
+end
+
+def get_options_from_keyvalue_config(file)
+  config = {}
+  File.readlines(file).map do |line|
+    k, v = line.split('=')
+    config[k.rstrip] = v.lstrip.chomp if k && v
+  end
+
+  result = []
+
+  result << "--port #{config['port']}" unless config['port'].nil?
+  result << "--ssl --host #{Facter.value(:fqdn)}" if config['ssl'] == 'requireSSL'
+  result << "--sslPEMKeyFile #{config['sslcert']}" unless config['sslcert'].nil?
+  result << "--sslCAFile #{config['sslca']}" unless config['sslca'].nil?
+  result << '--ipv6' unless config['ipv6'].nil?
+
+  result.join(' ')
+end
+
+def get_options_from_config(file)
+  config = YAML.load_file(file)
+  if config.is_a?(Hash) # Using a valid YAML file for mongo 2.6
+    get_options_from_hash_config(config)
+  else # It has to be a key-value config file
+    get_options_from_keyvalue_config(file)
+  end
+end
+
 Facter.add('mongodb_is_master') do
   setcode do
     if %w[mongo mongod].all? { |m| Facter::Util::Resolution.which m }
       file = mongod_conf_file
-      config = YAML.load_file(file)
-      mongo_port = nil
-      if config.is_a?(Hash) # Using a valid YAML file for mongo 2.6
-        unless config['net.port'].nil?
-          mongo_port = "--port #{config['net.port']}"
-        end
-        if config['net.ssl.mode'] == 'requireSSL'
-          ssl = "--ssl --host #{Facter.value(:fqdn)}"
-        end
-        unless config['net.ssl.PEMKeyFile'].nil?
-          sslkey = "--sslPEMKeyFile #{config['net.ssl.PEMKeyFile']}"
-        end
-        unless config['net.ssl.CAFile'].nil?
-          sslca = "--sslCAFile #{config['net.ssl.CAFile']}"
-        end
-        ipv6 = '--ipv6' unless config['net.ipv6'].nil?
-      else # It has to be a key-value config file
-        config = {}
-        File.readlines(file).map do |line|
-          k, v = line.split('=')
-          config[k.rstrip] = v.lstrip.chomp if k && v
-        end
-        mongo_port = "--port #{config['port']}" unless config['port'].nil?
-        if config['ssl'] == 'requireSSL'
-          ssl = "--ssl --host #{Facter.value(:fqdn)}"
-        end
-        unless config['sslcert'].nil?
-          sslkey = "--sslPEMKeyFile #{config['sslcert']}"
-        end
-        sslca = "--sslCAFile #{config['sslca']}" unless config['sslca'].nil?
-        ipv6 = '--ipv6' unless config['ipv6'].nil?
-      end
+      options = get_config_options(file)
       e = File.exist?('/root/.mongorc.js') ? 'load(\'/root/.mongorc.js\'); ' : ''
 
       # Check if the mongodb server is responding:
-      Facter::Core::Execution.exec("mongo --quiet #{ssl} #{sslkey} #{sslca} #{ipv6} #{mongo_port} --eval \"#{e}printjson(db.adminCommand({ ping: 1 }))\"")
+      Facter::Core::Execution.exec("mongo --quiet #{options} --eval \"#{e}printjson(db.adminCommand({ ping: 1 }))\"")
 
       if $CHILD_STATUS.success?
-        Facter::Core::Execution.exec("mongo --quiet #{ssl} #{sslkey} #{sslca} #{ipv6} #{mongo_port} --eval \"#{e}db.isMaster().ismaster\"")
+        Facter::Core::Execution.exec("mongo --quiet #{options} --eval \"#{e}db.isMaster().ismaster\"")
       else
         'not_responding'
       end


### PR DESCRIPTION
When using the RH MongoDB 3.4 SCL the config file is in /etc/opt/rh/rh-mongodb34/mongod.conf which causes this fact to fail because the -syspaths package still installs the binaries to /usr/bin.  Since we don't use this fact, it's enough for now to gracefully handle this.

Ideally we could use the value for mongodb::server::config but I'm not aware of a way to do this in facts.