### PR TITLE
Fix a circular loading issue with mongodb::repo

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -39,15 +39,17 @@ class mongodb::globals (
 ) {
 
   # Setup of the repo only makes sense globally, so we are doing it here.
-  if($manage_package_repo) {
+  if $manage_package_repo {
     if $use_enterprise_repo == true and $version == undef {
       fail('You must set mongodb::globals::version when mongodb::globals::use_enterprise_repo is true')
     }
 
     class { 'mongodb::repo':
-      ensure        => present,
-      repo_location => $repo_location,
-      proxy         => $repo_proxy,
+      ensure              => present,
+      version             => $version,
+      use_enterprise_repo => $use_enterprise_repo,
+      repo_location       => $repo_location,
+      proxy               => $repo_proxy,
     }
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,9 +1,10 @@
 # PRIVATE CLASS: do not use directly
 class mongodb::repo (
-  $ensure         = $mongodb::params::ensure,
-  $version        = $mongodb::params::version,
-  $repo_location  = undef,
-  $proxy          = undef,
+  $ensure = $mongodb::params::ensure,
+  $version = $mongodb::params::version,
+  $use_enterprise_repo = $mongodb::params::use_enterprise_repo,
+  $repo_location = undef,
+  $proxy = undef,
   $proxy_username = undef,
   $proxy_password = undef,
 ) inherits mongodb::params {
@@ -15,7 +16,7 @@ class mongodb::repo (
       if ($repo_location != undef){
         $location = $repo_location
         $description = 'MongoDB Custom Repository'
-      } elsif $mongodb::globals::use_enterprise_repo == true {
+      } elsif $use_enterprise_repo == true {
         $location = "https://repo.mongodb.com/yum/redhat/\$releasever/mongodb-enterprise/${mongover[0]}.${mongover[1]}/\$basearch/"
         $description = 'MongoDB Enterprise Repository'
       }
@@ -44,7 +45,7 @@ class mongodb::repo (
         $location = $repo_location
       }
       elsif $version and (versioncmp($version, '3.0.0') >= 0) {
-        if $mongodb::globals::use_enterprise_repo == true {
+        if $use_enterprise_repo == true {
             $repo_domain = 'repo.mongodb.com'
             $repo_path   = 'mongodb-enterprise'
         } else {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,13 +1,13 @@
 # PRIVATE CLASS: do not use directly
 class mongodb::repo (
-  $ensure = $mongodb::params::ensure,
-  $version = $mongodb::params::version,
-  $use_enterprise_repo = $mongodb::params::use_enterprise_repo,
+  Variant[Enum['present', 'absent'], Boolean] $ensure = 'present',
+  Optional[String] $version = undef,
+  Boolean $use_enterprise_repo = false,
   $repo_location = undef,
   $proxy = undef,
   $proxy_username = undef,
   $proxy_password = undef,
-) inherits mongodb::params {
+) {
   case $::osfamily {
     'RedHat', 'Linux': {
       if $version != undef {

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -17,7 +17,7 @@ class mongodb::repo::yum inherits mongodb::repo {
   }
   else {
     yumrepo { 'mongodb':
-      enabled => absent,
+      ensure => absent,
     }
   }
 }


### PR DESCRIPTION
mongodb::globals includes mongodb::repo mongodb::repo inherits from
mongodb::params mongodb::params inherits from globals

We work around this by removing the inheritance from mongodb::repo and
requiring explicit parameters. We then pass in the parameters explicitly in
mongodb::globals. Since repo is a private class this shouldn't be
considered breaking an API. While we're at it we add types to the
parameters we change.

Fixes #428

Also ensures the yumrepo is absent rather than disabled.