### PR TITLE
catch errors based on missing authentication to allow creation of admin user on replicaset setup

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -140,7 +140,9 @@ class Puppet::Provider::Mongodb < Puppet::Provider
                      cmd_ismaster
                    end
     res = mongo_cmd(db, conn_string, full_command).to_s.chomp
-    if res =~ %r{Authentication failed}
+
+    # Retry command without authentication when mongorc_file is set and authentication failed
+    if mongorc_file  && res =~ %r{Authentication failed}
       res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
     end
     res.eql?('true') ? true : false

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -134,14 +134,13 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     cmd_ismaster = 'db.isMaster().ismaster'
     db = 'admin'
 
-    if mongorc_file
-      full_command=mongorc_file + cmd_ismaster
-    else
-      full_command=cmd_ismaster
-
-    end
+    full_command = if mongorc_file
+                     mongorc_file + cmd_ismaster
+                   else
+                     cmd_ismaster
+                   end
     res = mongo_cmd(db, conn_string, full_command).to_s.chomp
-    if res.match('Authentication failed')
+    if res =~ 'Authentication failed'
       res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
     end
     res.eql?('true') ? true : false

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -138,10 +138,8 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       res = mongo_cmd(db, conn_string, mongorc_file + cmd_ismaster).to_s.chomp
     end
     if res.match(/Authentication failed/) or not mongorc_file
-      Puppet.warning('db_ismaster authentication failed')
       res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
     end
-    Puppet.warning("db_ismaster res: #{res}")
     res.eql?('true') ? true : false
   end
 
@@ -159,8 +157,6 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     retry_count = retries
     retry_sleep = 3
     cmd = mongorc_file + cmd if mongorc_file
-
-    Puppet.warning("mongoeval cmd: #{cmd}")
 
     out = nil
     retry_count.times do |n|

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -140,7 +140,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
                      cmd_ismaster
                    end
     res = mongo_cmd(db, conn_string, full_command).to_s.chomp
-    if res =~ 'Authentication failed'
+    if res =~ %r{Authentication failed}
       res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
     end
     res.eql?('true') ? true : false

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -142,7 +142,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     res = mongo_cmd(db, conn_string, full_command).to_s.chomp
 
     # Retry command without authentication when mongorc_file is set and authentication failed
-    if mongorc_file  && res =~ %r{Authentication failed}
+    if mongorc_file && res =~ %r{Authentication failed}
       res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
     end
     res.eql?('true') ? true : false

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -137,7 +137,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     if mongorc_file
       res = mongo_cmd(db, conn_string, mongorc_file + cmd_ismaster).to_s.chomp
     end
-    if res.match('Authentication failed') || ! mongorc_file
+    if res.match('Authentication failed') || !mongorc_file
       res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
     end
     res.eql?('true') ? true : false

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -135,9 +135,13 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     db = 'admin'
 
     if mongorc_file
-      res = mongo_cmd(db, conn_string, mongorc_file + cmd_ismaster).to_s.chomp
+      full_command=mongorc_file + cmd_ismaster
+    else
+      full_command=cmd_ismaster
+
     end
-    if res.match('Authentication failed') || !mongorc_file
+    res = mongo_cmd(db, conn_string, full_command).to_s.chomp
+    if res.match('Authentication failed')
       res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
     end
     res.eql?('true') ? true : false

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -137,7 +137,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     if mongorc_file
       res = mongo_cmd(db, conn_string, mongorc_file + cmd_ismaster).to_s.chomp
     end
-    if res.match(/Authentication failed/) or not mongorc_file
+    if res.match('Authentication failed') || ! mongorc_file
       res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
     end
     res.eql?('true') ? true : false

--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
   def self.prefetch(resources)
     dbs = instances
     resources.keys.each do |name|
-      provider = dbs.find {|db| db.name == name}
+      provider = dbs.find { |db| db.name == name }
       resources[name].provider = provider if provider
     end
   end

--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
         new(name: db['name'],
             ensure: :present)
       end
-    rescue e
+    rescue StandardError => e
       Puppet.warning('Getting instances of mongodb_database failed: #{e}')
       []
     end

--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -13,8 +13,8 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
         new(name: db['name'],
             ensure: :present)
       end
-    rescue StandardError => e
-      Puppet.warning('Getting instances of mongodb_database failed: #{e}')
+    rescue => e
+      Puppet.warning("Getting instances of mongodb_database failed: #{e}")
       []
     end
   end

--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -6,24 +6,22 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
 
   def self.instances
     require 'json'
-    begin
-      dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs())')
+    dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs())')
 
-      dbs['databases'].map do |db|
-        new(name: db['name'],
-            ensure: :present)
-      end
-    rescue => e
-      Puppet.warning("Getting instances of mongodb_database failed: #{e}")
-      []
+    dbs['databases'].map do |db|
+      new(name: db['name'],
+          ensure: :present)
     end
+  rescue => e
+    Puppet.warning("Getting instances of mongodb_database failed: #{e}")
+    []
   end
 
   # Assign prefetched dbs based on name.
   def self.prefetch(resources)
     dbs = instances
     resources.keys.each do |name|
-      provider = dbs.find { |db| db.name == name }
+      provider = dbs.find {|db| db.name == name}
       resources[name].provider = provider if provider
     end
   end

--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -6,11 +6,15 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
 
   def self.instances
     require 'json'
-    dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs())')
+    begin
+      dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs())')
 
-    dbs['databases'].map do |db|
-      new(name: db['name'],
-          ensure: :present)
+      dbs['databases'].map do |db|
+        new(name: db['name'],
+            ensure: :present)
+      end
+    rescue
+      {}
     end
   end
 
@@ -18,7 +22,7 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
   def self.prefetch(resources)
     dbs = instances
     resources.keys.each do |name|
-      provider = dbs.find { |db| db.name == name }
+      provider = dbs.find {|db| db.name == name}
       resources[name].provider = provider if provider
     end
   end

--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -13,8 +13,9 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
         new(name: db['name'],
             ensure: :present)
       end
-    rescue
-      {}
+    rescue e
+      Puppet.warning('Getting instances of mongodb_database failed: #{e}')
+      []
     end
   end
 
@@ -22,7 +23,7 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
   def self.prefetch(resources)
     dbs = instances
     resources.keys.each do |name|
-      provider = dbs.find {|db| db.name == name}
+      provider = dbs.find { |db| db.name == name }
       resources[name].provider = provider if provider
     end
   end

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -39,8 +39,9 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
                 password_hash: user['credentials']['MONGODB-CR'],
                 scram_credentials: user['credentials']['SCRAM-SHA-1'])
           end
-        rescue
-          {}
+        rescue e
+      	  Puppet.warning 'Could not get instances for mongodb_database: #{e}'
+          []
         end
       end
     else
@@ -53,7 +54,7 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
   def self.prefetch(resources)
     users = instances
     resources.each do |name, resource|
-      provider = users.find {|user| user.username == (resource[:username]) && user.database == (resource[:database])}
+      provider = users.find { |user| user.username == (resource[:username]) && user.database == (resource[:database]) }
       resources[name].provider = provider if provider
     end
   end

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -39,8 +39,8 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
                 password_hash: user['credentials']['MONGODB-CR'],
                 scram_credentials: user['credentials']['SCRAM-SHA-1'])
           end
-        rescue StandardError => e
-          Puppet.warning 'Could not get instances for mongodb_database: #{e}'
+        rescue => e
+          Puppet.warning "Could not get instances for mongodb_database: #{e}"
           []
         end
       end

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
                 scram_credentials: user['credentials']['SCRAM-SHA-1'])
           end
         rescue e
-      	  Puppet.warning 'Could not get instances for mongodb_database: #{e}'
+          Puppet.warning 'Could not get instances for mongodb_database: #{e}'
           []
         end
       end
@@ -68,9 +68,9 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
           raise Puppet::Error, "password_hash can't be set on MongoDB older than 3.0; use password instead"
         end
         user = {
-            user: @resource[:username],
-            pwd: @resource[:password],
-            roles: @resource[:roles]
+          user: @resource[:username],
+          pwd: @resource[:password],
+          roles: @resource[:roles]
         }
 
         mongo_eval("db.addUser(#{user.to_json})", @resource[:database])

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
                 password_hash: user['credentials']['MONGODB-CR'],
                 scram_credentials: user['credentials']['SCRAM-SHA-1'])
           end
-        rescue e
+        rescue StandardError => e
           Puppet.warning 'Could not get instances for mongodb_database: #{e}'
           []
         end


### PR DESCRIPTION
#### Pull Request (PR) description
When setting up a new replica set with authentication enabled the puppet run fails because some exceptions were not caught properly, when getting the user and database instances. When checking if the mongodb is a primary node a recheck without authentication is done to be able to create the admin user.

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
