### PR TITLE
Fallback to monogb version from fact if no explicit version got provided

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -69,7 +69,7 @@ class mongodb::server::config {
   $storage_engine   = $mongodb::server::storage_engine
 
   if $mongodb::server::version == undef or $mongodb::server::version == '' {
-    $version = $::mongodb_version
+    $version = $facts['mongodb_version']
   } else {
     $version = $mongodb::server::version
   }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -67,7 +67,12 @@ class mongodb::server::config {
   $ssl_invalid_hostnames = $mongodb::server::ssl_invalid_hostnames
   $ssl_mode         = $mongodb::server::ssl_mode
   $storage_engine   = $mongodb::server::storage_engine
-  $version          = $mongodb::server::version
+
+  if $mongodb::server::version == undef or $mongodb::server::version == '' {
+    $version = $::mongodb_version
+  } else {
+    $version = $mongodb::server::version
+  }
 
   File {
     owner => $user,

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -1,4 +1,5 @@
 #mongodb.conf - generated from Puppet
+# Generated for MongoDB version <%= @version %>
 
 #System Log
 

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -1,4 +1,5 @@
 # mongodb.conf - generated from Puppet
+# Generated for MongoDB version <%= @version %>
 
 
 <% if @logpath -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    The class mongodb::server::config uses the wrong template, if $mongodb::server::version is not set, and the version of the mongodb is >= 2.6.0.

    The patch is using the custom fact 'mongodb_version' for the case, if the version is not set in another way.

-->

#### This Pull Request (PR) fixes the following issues
<!--
    n/a
-->
