### PR TITLE
Move to Debian 9 and Ubuntu 16.04/18.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -171,27 +171,4 @@ class mongodb::params inherits mongodb::globals {
       fail("Osfamily ${::osfamily} and ${::operatingsystem} is not supported")
     }
   }
-
-  case $::operatingsystem {
-    'Debian': {
-      case $::operatingsystemmajrelease {
-        '8': {
-          $service_provider = pick($service_provider, 'systemd')
-        }
-        default: {
-          $service_provider = pick($service_provider, 'debian')
-        }
-      }
-    }
-    'Ubuntu': {
-      if versioncmp($::operatingsystemmajrelease, '16') >= 0 {
-        $service_provider = pick($service_provider, 'systemd')
-      } else {
-        $service_provider = pick($service_provider, 'upstart')
-      }
-    }
-    default: {
-      $service_provider = undef
-    }
-  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -23,14 +23,14 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "9"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     }
   ],


### PR DESCRIPTION
We should be able to rely on Puppet setting the correct defaults.

Fixes GH-488