### PR TITLE
#512: Current 'sharding.pp' example typo

### DIFF
--- a/examples/sharding.pp
+++ b/examples/sharding.pp
@@ -5,7 +5,7 @@ node 'mongos' {
   }
   -> class {'mongodb::server':
     configsvr => true,
-    bind_ip   => $::ipaddress,
+    bind_ip   => [$::ipaddress],
   }
   -> class {'mongodb::client': }
   -> class {'mongodb::mongos':


### PR DESCRIPTION
This merge request fixes the `sharding.pp` example, by converting the `bind_ip` from a string, to an array. The corresponding solution has been manually [verified](https://github.com/jeff1evesque/ist-664/issues/10#issuecomment-432482378) per `puppet agent -t` on a puppet agent.

Resolves #512.