### PR TITLE
Provide additonal parameters to customize Debian repository

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -1,5 +1,13 @@
 # PRIVATE CLASS: do not use directly
-class mongodb::repo::apt inherits mongodb::repo {
+class mongodb::repo::apt(
+  $location = $mongodb::repo::location,
+  $release  = $mongodb::repo::release,
+  $repos    = $mongodb::repo::repos,
+  $key      = {
+    'id'     => $mongodb::repo::key,
+    'server' => $mongodb::repo::key_server,
+  }
+) inherits mongodb::repo {
   # we try to follow/reproduce the instruction
   # from http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
 
@@ -7,13 +15,10 @@ class mongodb::repo::apt inherits mongodb::repo {
 
   if($mongodb::repo::ensure == 'present' or $mongodb::repo::ensure == true) {
     apt::source { 'mongodb':
-      location => $mongodb::repo::location,
-      release  => $mongodb::repo::release,
-      repos    => $mongodb::repo::repos,
-      key      => {
-        'id'     => $mongodb::repo::key,
-        'server' => $mongodb::repo::key_server,
-      },
+      location => $location,
+      release  => $release,
+      repos    => $repos,
+      key      => $key,
     }
 
     Apt::Source['mongodb']->Package<|tag == 'mongodb'|>


### PR DESCRIPTION
mongodb::repo::repo_location does not work for Debian, because of
missing additional variables, created in different place:
* release
* repos.
* keys

I parametrized mongodb::repo::apt because it was easier, than hacking
repo.pp