### PR TITLE
Add aptkey_options parameter to mongodb::repo class

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -27,7 +27,7 @@ class mongodb::repo (
         }
       }
 
-      contain ::mongodb::repo::yum
+      contain mongodb::repo::yum
     }
 
     'Debian': {
@@ -65,7 +65,7 @@ class mongodb::repo (
         $key_server = 'hkp://keyserver.ubuntu.com:80'
       }
 
-      contain ::mongodb::repo::apt
+      contain mongodb::repo::apt
     }
 
     default: {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,13 +1,13 @@
 # PRIVATE CLASS: do not use directly
 class mongodb::repo (
   Variant[Enum['present', 'absent'], Boolean] $ensure = 'present',
-  Optional[String] $version = undef,
-  Boolean $use_enterprise_repo = false,
-  Optional[String] $repo_location = undef,
-  Optional[String] $proxy = undef,
-  Optional[String] $proxy_username = undef,
-  Optional[String] $proxy_password = undef,
-  Optional[String] $aptkey_options = undef,
+  Optional[String] $version                           = undef,
+  Boolean $use_enterprise_repo                        = false,
+  Optional[String] $repo_location                     = undef,
+  Optional[String] $proxy                             = undef,
+  Optional[String] $proxy_username                    = undef,
+  Optional[String] $proxy_password                    = undef,
+  Optional[String[1]] $aptkey_options                 = undef,
 ) {
   case $::osfamily {
     'RedHat', 'Linux': {
@@ -27,7 +27,7 @@ class mongodb::repo (
         }
       }
 
-      contain mongodb::repo::yum
+      contain ::mongodb::repo::yum
     }
 
     'Debian': {
@@ -65,7 +65,7 @@ class mongodb::repo (
         $key_server = 'hkp://keyserver.ubuntu.com:80'
       }
 
-      contain mongodb::repo::apt
+      contain ::mongodb::repo::apt
     }
 
     default: {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -7,6 +7,7 @@ class mongodb::repo (
   Optional[String] $proxy = undef,
   Optional[String] $proxy_username = undef,
   Optional[String] $proxy_password = undef,
+  Optional[String] $aptkey_options = undef,
 ) {
   case $::osfamily {
     'RedHat', 'Linux': {

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -11,8 +11,9 @@ class mongodb::repo::apt inherits mongodb::repo {
       release  => $mongodb::repo::release,
       repos    => $mongodb::repo::repos,
       key      => {
-        'id'     => $mongodb::repo::key,
-        'server' => $mongodb::repo::key_server,
+        'id'      => $mongodb::repo::key,
+        'server'  => $mongodb::repo::key_server,
+        'options' => $mongodb::repo::aptkey_options,
       },
     }
 


### PR DESCRIPTION

#### Pull Request (PR) description
Adding an `aptkey_options` parameter so we can pass for example proxy settings to the `apt::key` resource via hiera:

```hiera
mongodb::repo::aptkey_options: 'http-proxy="http://proxyuser:proxypass@example.org:3128"'
```

