### PR TITLE
support percona mongodb version output

### DIFF
--- a/lib/facter/mongodb_version.rb
+++ b/lib/facter/mongodb_version.rb
@@ -2,7 +2,7 @@ Facter.add(:mongodb_version) do
   setcode do
     if Facter::Core::Execution.which('mongo')
       mongodb_version = Facter::Core::Execution.execute('mongo --version 2>&1')
-      %r{^MongoDB shell version:?\s+([\w\.]+)}.match(mongodb_version)[1]
+      %r{MongoDB shell version:?\s+v?([\w\.]+)}.match(mongodb_version)[1]
     end
   end
 end


### PR DESCRIPTION
Relaxes mongodb_version fact to support percona mongodb releases

Output from Percona-Server-MongoDB-34 `mongo --version`:

    Percona Server for MongoDB shell version v3.4.18-2.16
    git version: afb7426e953ba15421ac8cd917615649dac617ac
    OpenSSL version: OpenSSL 1.0.1e-fips 11 Feb 2013
    allocator: tcmalloc
    modules: none
    build environment:
        distarch: x86_64
        target_arch: x86_64
