### PR TITLE
Support global setting of mongodb client package

### DIFF
--- a/manifests/client/params.pp
+++ b/manifests/client/params.pp
@@ -8,7 +8,7 @@ class mongodb::client::params inherits mongodb::globals {
   } else {
     $package_name = $::osfamily ? {
       'Debian' => 'mongodb-clients',
-      default  => 'mongodb',
+      default  => pick($mongodb::globals::client_package_name, 'mongodb'),
     }
   }
 }


### PR DESCRIPTION
This existed in the previous 2.X line and allowed easier support for things like SCL versions of mongodb on Enterprise Linux.