### PR TITLE
Add support for replication.enableMajorityReadConcern setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,11 @@ class mongodb::server {
 }
 ```
 
+##### `repl_enable_majority_read_concern`
+Use this setting to configure replication.enableMajorityReadConcern setting.
+For more information please refer to [MongoDB Read Concern "majority"](https://dochub.mongodb.org/core/psa-disable-rc-majority-3.6).
+Default: true.
+
 ##### `config_data`
 A hash to allow for additional configuration options
 to be set in user-provided template.

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ class mongodb::server {
 ##### `repl_enable_majority_read_concern`
 Use this setting to configure replication.enableMajorityReadConcern setting.
 For more information please refer to [MongoDB Read Concern "majority"](https://dochub.mongodb.org/core/psa-disable-rc-majority-3.6).
-Default: true
+Default: undef (which implies the MongoDB default setting of true)
 
 ##### `config_data`
 A hash to allow for additional configuration options

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ class mongodb::server {
 ##### `repl_enable_majority_read_concern`
 Use this setting to configure replication.enableMajorityReadConcern setting.
 For more information please refer to [MongoDB Read Concern "majority"](https://dochub.mongodb.org/core/psa-disable-rc-majority-3.6).
-Default: true.
+Default: true
 
 ##### `config_data`
 A hash to allow for additional configuration options

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -79,6 +79,7 @@ class mongodb::server (
   Boolean $handle_creds                                 = $mongodb::params::handle_creds,
   Boolean $store_creds                                  = $mongodb::params::store_creds,
   Array $admin_roles                                    = $mongodb::params::admin_roles,
+  Optional[Boolean] $repl_enable_majority_read_concern  = undef,
 ) inherits mongodb::params {
 
   contain mongodb::server::install

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -67,6 +67,7 @@ class mongodb::server::config {
   $ssl_invalid_hostnames = $mongodb::server::ssl_invalid_hostnames
   $ssl_mode         = $mongodb::server::ssl_mode
   $storage_engine   = $mongodb::server::storage_engine
+  $repl_enable_majority_read_concern = $mongodb::server::repl_enable_majority_read_concern
 
   File {
     owner => $user,

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -331,14 +331,20 @@ describe 'mongodb::server' do
       end
 
       describe 'repl_enable_majority_read_concern param' do
-        [true, false].each do |value|
-          context "set to #{value}" do
-            let (:params) {
-              repl_enable_majority_read_concern: #{value}
-            }
+        context "set to true" do
+          let (:params) {
+            repl_enable_majority_read_concern: true
+          }
 
-            it { is_expected.to contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: #{value}$}) }
-          end
+          it { is_expected.to contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: true$}) }
+        end
+
+        context "set to false" do
+          let (:params) {
+            repl_enable_majority_read_concern: false
+          }
+
+          it { is_expected.to contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: false$}) }
         end
       end
 

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -332,17 +332,17 @@ describe 'mongodb::server' do
 
       describe 'repl_enable_majority_read_concern param' do
         context "set to true" do
-          let (:params) {
-            repl_enable_majority_read_concern: true
-          }
+          let(:params) do
+            { repl_enable_majority_read_concern: true }
+          end
 
           it { is_expected.to contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: true$}) }
         end
 
         context "set to false" do
-          let (:params) {
-            repl_enable_majority_read_concern: false
-          }
+          let(:params) do
+            { repl_enable_majority_read_concern: false }
+          end
 
           it { is_expected.to contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: false$}) }
         end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -333,8 +333,10 @@ describe 'mongodb::server' do
       describe 'repl_enable_majority_read_concern param' do
         [true, false].each do |value|
           context "set to #{value}" do
-            let (:params) { { repl_enable_majority_read_concern: #{value} } }
-            
+            let (:params) {
+              repl_enable_majority_read_concern: #{value}
+            }
+
             it { is_expected.to contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: #{value}$}) }
           end
         end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -48,7 +48,7 @@ describe 'mongodb::server' do
             with_content(%r{^net\.bindIp:  127\.0\.0\.1$}).
             with_content(%r{^systemLog\.logAppend: true$}).
             with_content(%r{^systemLog\.path: #{log_path}$}).
-            without_content(%r{^replication\.enableMajorityReadConcern:.*$})
+            without_content(%r{^replication\.enableMajorityReadConcern:})
         end
 
         if facts[:os]['family'] == 'Debian'

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -335,7 +335,7 @@ describe 'mongodb::server' do
           context "set to #{value}" do
             let (:params) { { repl_enable_majority_read_concern: #{value} } }
             
-            it { should contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: #{value}$} ) }
+            it { is_expected.to contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: #{value}$}) }
           end
         end
       end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -333,9 +333,9 @@ describe 'mongodb::server' do
       describe 'repl_enable_majority_read_concern param' do
         [true, false].each do |value|
           context "set to #{value}" do
-            let (:params) { { :repl_enable_majority_read_concern => value } }
+            let (:params) { { repl_enable_majority_read_concern: #{value} } }
             
-            it { should contain_file(config_file).with_content(/^\s*replication\.enableMajorityReadConcern: #{value}$/) }
+            it { should contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: #{value}$} ) }
           end
         end
       end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -331,7 +331,7 @@ describe 'mongodb::server' do
       end
 
       describe 'repl_enable_majority_read_concern param' do
-        context "set to true" do
+        context 'set to true' do
           let(:params) do
             { repl_enable_majority_read_concern: true }
           end
@@ -339,7 +339,7 @@ describe 'mongodb::server' do
           it { is_expected.to contain_file(config_file).with_content(%r{^\s*replication\.enableMajorityReadConcern: true$}) }
         end
 
-        context "set to false" do
+        context 'set to false' do
           let(:params) do
             { repl_enable_majority_read_concern: false }
           end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -47,7 +47,8 @@ describe 'mongodb::server' do
             with_content(%r{^storage\.dbPath: /var/lib/mongodb$}).
             with_content(%r{^net\.bindIp:  127\.0\.0\.1$}).
             with_content(%r{^systemLog\.logAppend: true$}).
-            with_content(%r{^systemLog\.path: #{log_path}$})
+            with_content(%r{^systemLog\.path: #{log_path}$}).
+            without_content(%r{^replication\.enableMajorityReadConcern:.*$})
         end
 
         if facts[:os]['family'] == 'Debian'
@@ -326,6 +327,20 @@ describe 'mongodb::server' do
           end
 
           it { is_expected.to contain_file(config_file).with_content(%r{^net\.http\.enabled: true$}) }
+        end
+      end
+
+      describe 'repl_enable_majority_read_concern param' do
+        [true, false, undef].each do |value|
+          context "set to #{value}" do
+            let (:params) { { :repl_enable_majority_read_concern => value } }
+            
+            if value == undef
+              it { is_expected.to contain_file(config_file).without_content(%r{^replication\.enableMajorityReadConcern:.*$}) }
+            else
+              it { should contain_file(config_file).with_content(/^\s*replication\.enableMajorityReadConcern: #{value}$/) }
+            end
+          end
         end
       end
 

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -331,15 +331,11 @@ describe 'mongodb::server' do
       end
 
       describe 'repl_enable_majority_read_concern param' do
-        [true, false, undef].each do |value|
+        [true, false].each do |value|
           context "set to #{value}" do
             let (:params) { { :repl_enable_majority_read_concern => value } }
             
-            if value == undef
-              it { is_expected.to contain_file(config_file).without_content(%r{^replication\.enableMajorityReadConcern:.*$}) }
-            else
-              it { should contain_file(config_file).with_content(/^\s*replication\.enableMajorityReadConcern: #{value}$/) }
-            end
+            it { should contain_file(config_file).with_content(/^\s*replication\.enableMajorityReadConcern: #{value}$/) }
           end
         end
       end

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -129,6 +129,9 @@ replication.replSetName: <%= @replset %>
 <% if @oplog_size -%>
 replication.oplogSizeMB: <%= @oplog_size %>
 <% end -%>
+<% if @repl_enable_majority_read_concern -%>
+replication.enableMajorityReadConcern: <%= @repl_enable_majority_read_concern %>
+<% end -%>
 
 #Sharding
 <% if @configsvr -%>

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -129,7 +129,7 @@ replication.replSetName: <%= @replset %>
 <% if @oplog_size -%>
 replication.oplogSizeMB: <%= @oplog_size %>
 <% end -%>
-<% if @repl_enable_majority_read_concern -%>
+<% if defined?(@repl_enable_majority_read_concern) -%>
 replication.enableMajorityReadConcern: <%= @repl_enable_majority_read_concern %>
 <% end -%>
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add support for replication.enableMajorityReadConcern setting in mongod.conf.

#### This Pull Request (PR) fixes the following issues
#542 
