### PR TITLE
allow other databases in the format 'role@db' for mongodb_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,10 @@ For more information please refer to [MongoDB Authentication Process](http://doc
 Plain-text user password (will be hashed)
 
 ##### `roles`
-Array with user roles. Default: ['dbAdmin']
+Array with user roles as string.
+Roles will be granted to user's database if no alternative database is explicitly defined.
+Example: ['dbAdmin', 'readWrite@other_database']
+Default: ['dbAdmin']
 
 ##### `opsmanager_url`
 The fully qualified url where opsmanager runs. Must include the port. Ex:
@@ -716,7 +719,10 @@ Plaintext password of the user.
 Name of database. It will be created, if not exists.
 
 ##### `roles`
-Array with user roles. Default: ['dbAdmin']
+Array with user roles as string.
+Roles will be granted to user's database if no alternative database is explicitly defined.
+Example: ['dbAdmin', 'readWrite@other_database']
+Default: ['dbAdmin']
 
 ##### `tries`
 The maximum amount of two second tries to wait MongoDB startup. Default: 10

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -49,7 +49,7 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
         customData: {
           createdBy: "Puppet Mongodb_user['#{@resource[:name]}']"
         },
-        roles: @resource[:roles],
+        roles: role_hashes(@resource[:roles], @resource[:database]),
         digestPassword: false
       }
 
@@ -105,14 +105,14 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
 
   def roles=(roles)
     if db_ismaster
-      grant = roles - @property_hash[:roles]
+      grant = to_roles(roles, @resource[:database]) - to_roles(@property_hash[:roles], @resource[:database])
       unless grant.empty?
-        mongo_eval("db.getSiblingDB(#{@resource[:database].to_json}).grantRolesToUser(#{@resource[:username].to_json}, #{grant.to_json})")
+        mongo_eval("db.getSiblingDB(#{@resource[:database].to_json}).grantRolesToUser(#{@resource[:username].to_json}, #{role_hashes(grant, @resource[:database]).to_json})")
       end
 
-      revoke = @property_hash[:roles] - roles
+      revoke = to_roles(@property_hash[:roles], @resource[:database]) - to_roles(roles, @resource[:database])
       unless revoke.empty?
-        mongo_eval("db.getSiblingDB(#{@resource[:database].to_json}).revokeRolesFromUser(#{@resource[:username].to_json}, #{revoke.to_json})")
+        mongo_eval("db.getSiblingDB(#{@resource[:database].to_json}).revokeRolesFromUser(#{@resource[:username].to_json}, #{role_hashes(revoke, @resource[:database]).to_json})")
       end
     else
       Puppet.warning 'User roles operations are available only from master host'
@@ -123,11 +123,37 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
 
   def self.from_roles(roles, db)
     roles.map do |entry|
-      if entry['db'] == db
+      if entry['db'].empty? || entry['db'] == db
         entry['role']
       else
         "#{entry['role']}@#{entry['db']}"
       end
     end.sort
+  end
+
+  def to_roles(roles, db)
+    roles.map do |entry|
+      if entry.include? '@'
+        entry
+      else
+        "#{entry}@#{db}"
+      end
+    end
+  end
+
+  def role_hashes(roles, db)
+    roles.sort.map do |entry|
+      if entry.include? '@'
+        {
+          'role' => entry.gsub(%r{^(.*)@.*$}, '\1'),
+          'db'   => entry.gsub(%r{^.*@(.*)$}, '\1')
+        }
+      else
+        {
+          'role' => entry,
+          'db'   => db
+        }
+      end
+    end
   end
 end

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -40,7 +40,7 @@ Puppet::Type.newtype(:mongodb_user) do
   newproperty(:roles, array_matching: :all) do
     desc "The user's roles."
     defaultto ['dbAdmin']
-    newvalue(%r{^\w+$})
+    newvalue(%r{^\w+(@\w+)?$})
 
     # Pretty output for arrays.
     def should_to_s(value)

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -104,7 +104,7 @@ describe 'mongodb_database' do
     end
 
     it 'creates the user' do
-      shell("mongo testuser2 --quiet --eval 'db.auth(\"testuser\",\"passw0rd\")'") do |r|
+      shell("mongo testdb --quiet --eval 'db.auth(\"testuser2\",\"passw0rd\")'") do |r|
         expect(r.stdout.chomp).to eq('1')
       end
     end

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -104,7 +104,7 @@ describe 'mongodb_database' do
     end
 
     it 'creates the user' do
-      shell("mongo testdb --quiet --eval 'db.auth(\"testuser\",\"passw0rd\")'") do |r|
+      shell("mongo testuser2 --quiet --eval 'db.auth(\"testuser\",\"passw0rd\")'") do |r|
         expect(r.stdout.chomp).to eq('1')
       end
     end

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -87,7 +87,15 @@ describe 'mongodb_database' do
         mongodb_user {'testuser':
           ensure        => present,
           password_hash => mongodb_password('testuser', 'passw0rd'),
-          roles         => ['readWrite@testdb', 'dbAdmin@testdb'],
+          database      => 'testdb',
+          roles         => ['readWrite', 'dbAdmin'],
+        }
+        ->
+        mongodb_user {'testuser2':
+          ensure        => present,
+          password_hash => mongodb_password('testuser2', 'passw0rd'),
+          database      => 'testdb2',
+          roles         => ['readWrite@testdb', 'dbAdmin@testdb', 'dbAdmin'],
         }
       EOS
 

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -51,7 +51,7 @@ describe 'mongodb_database' do
     end
   end
 
-  context 'with basic roles syntax' do
+  context 'with the basic roles syntax' do
     it 'compiles with no errors' do
       pp = <<-EOS
         class { 'mongodb::server': }
@@ -77,7 +77,7 @@ describe 'mongodb_database' do
     end
   end
 
-  context 'with the new roles syntax' do
+  context 'with the new multidb role syntax' do
     it 'compiles with no errors' do
       pp = <<-EOS
         class { 'mongodb::server': }
@@ -96,7 +96,7 @@ describe 'mongodb_database' do
           ensure        => present,
           password_hash => mongodb_password('testuser2', 'passw0rd'),
           database      => 'testdb2',
-          roles         => ['readWrite@testdb', 'dbAdmin@testdb', 'readWrite', 'dbAdmin'],
+          roles         => ['readWrite', 'dbAdmin', 'readWrite@testdb', 'dbAdmin@testdb'],
         }
       EOS
 
@@ -106,6 +106,12 @@ describe 'mongodb_database' do
 
     it 'allows the testuser' do
       shell("mongo testdb --quiet --eval 'db.auth(\"testuser\",\"passw0rd\")'") do |r|
+        expect(r.stdout.chomp).to eq('1')
+      end
+    end
+
+    it 'allows the second user to connect to its default database' do
+      shell("mongo testdb2 --quiet --eval 'db.auth(\"testuser2\",\"passw0rd\")'") do |r|
         expect(r.stdout.chomp).to eq('1')
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

I added some acceptance tests for this PR: https://github.com/voxpupuli/puppet-mongodb/pull/432
which is based on #308 

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes https://github.com/voxpupuli/puppet-mongodb/issues/460
