### PR TITLE
Only create database and user when mongodb_is_master

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -20,7 +20,7 @@ define mongodb::db (
   Integer[0]       $tries         = 10,
 ) {
 
-  if $facts['mongodb_is_master'] == 'true' { # lint:ignore:quoted_booleans
+  unless $facts['mongodb_is_master'] == 'false' { # lint:ignore:quoted_booleans
     mongodb_database { $db_name:
       ensure => present,
       tries  => $tries,

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -20,25 +20,26 @@ define mongodb::db (
   Integer[0]       $tries         = 10,
 ) {
 
-  mongodb_database { $db_name:
-    ensure => present,
-    tries  => $tries,
-  }
+  if $facts['mongodb_is_master'] == 'true' { # lint:ignore:quoted_booleans
+    mongodb_database { $db_name:
+      ensure => present,
+      tries  => $tries,
+    }
 
-  if $password_hash {
-    $hash = $password_hash
-  } elsif $password {
-    $hash = mongodb_password($user, $password)
-  } else {
-    fail("Parameter 'password_hash' or 'password' should be provided to mongodb::db.")
-  }
+    if $password_hash {
+      $hash = $password_hash
+    } elsif $password {
+      $hash = mongodb_password($user, $password)
+    } else {
+      fail("Parameter 'password_hash' or 'password' should be provided to mongodb::db.")
+    }
 
-  mongodb_user { "User ${user} on db ${db_name}":
-    ensure        => present,
-    password_hash => $hash,
-    username      => $user,
-    database      => $db_name,
-    roles         => $roles,
+    mongodb_user { "User ${user} on db ${db_name}":
+      ensure        => present,
+      password_hash => $hash,
+      username      => $user,
+      database      => $db_name,
+      roles         => $roles,
+    }
   }
-
 }


### PR DESCRIPTION

#### Pull Request (PR) description
Only create database and user when running on a primary/master node. This way we have idempotent runs again on none primary servers. 

Unfortunately the fact returns a string `true` so there is some ugliness with `lint:ignore` in the if statement.

#### This Pull Request (PR) fixes the following issues
Fixes #412
