### PR TITLE
Fixed the problem: the user was not created for Mongodb 4.x

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -174,4 +174,13 @@ class Puppet::Provider::Mongodb < Puppet::Provider
   def mongo_26?
     self.class.mongo_26?
   end
+
+  def self.mongo_4?
+    v = mongo_version
+    !v[%r{^4\.}].nil?
+  end
+
+  def mongo_4?
+    self.class.mongo_4?
+  end
 end

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -53,6 +53,11 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
         digestPassword: false
       }
 
+      if mongo_4?
+        # SCRAM-SHA-256 requires digestPassword to be true.
+        command[:mechanisms] = ['SCRAM-SHA-1']
+      end
+
       mongo_eval("db.runCommand(#{command.to_json})", @resource[:database])
     else
       Puppet.warning 'User creation is available only from master host'


### PR DESCRIPTION
When creating a user, a password hash is used and the "digestPassword" option is set to "false". By default in Mongodb 4.x the parameter "mechanisms" is set to ["SCRAM-SHA-1","SCRAM-SHA-256"], but according to the documentation (https://docs.mongodb.com/manual/reference/command/createUser/ ) for SCRAM-SHA-256 "digestPassword" cannot be "false".

Example:
```
$ mongo admin --quiet --host 127.0.0.1:27017 --eval "load('/root/.mongorc.js'); db.runCommand({\"createUser\":\"test\",\"pwd\":\"398fefcb5925a718fd0c812bbeb7e101\",\"customData\":{\"createdBy\":\"Puppet Mongodb_user['test']\"},\"roles\":[\"clusterMonitor\"],\"digestPassword\":false})"
```

output:
```
{
	"ok" : 0,
	"errmsg" : "Use of SCRAM-SHA-256 requires undigested passwords",
	"code" : 2,
	"codeName" : "BadValue"
}
```
If you remove SCRAM-SHA-256, it works correctly:
```
$ mongo admin --quiet --host 127.0.0.1:27017 --eval "load('/root/.mongorc.js'); db.runCommand({\"createUser\":\"test\",\"pwd\":\"398fefcb5925a718fd0c812bbeb7e101\",\"customData\":{\"createdBy\":\"Puppet Mongodb_user['test']\"},\"roles\":[\"clusterMonitor\"],\"digestPassword\":false, \"mechanisms\":[\"SCRAM-SHA-1\"]})"
```
output:
```
{ "ok" : 1 }
```

Thus, you need to add SCRAM-SHA-256 support, not use "password_hash" and set digestPassword to "true", or just use SCRAM-SHA-1, which seemed to me the simplest solution, which does not require global changes.


Fixes #525

