### PR TITLE
restrict opsmanager conf file permissions for better security

### DIFF
--- a/manifests/opsmanager/config.pp
+++ b/manifests/opsmanager/config.pp
@@ -7,7 +7,7 @@ class mongodb::opsmanager::config {
     ensure  => file,
     owner   => $user,
     group   => $group,
-    mode    => '0644',
+    mode    => '0640',
     content => epp('mongodb/opsmanager/conf-mms.properties.epp'),
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Restrict Opsmanager conf file permissions for better security, because there are a password stored in the MongoURI property. 
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
