### PR TITLE
Add default localhost real_ip

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -103,7 +103,11 @@ class Puppet::Provider::Mongodb < Puppet::Provider
                 else
                   27_017
                 end
-
+    ip_real = if ip_real
+                ip_real 
+              else 
+                '127.0.0.1'
+              end
     "#{ip_real}:#{port_real}"
   end
 


### PR DESCRIPTION
#### Pull Request (PR) description
Sometimes you just want to add a user or two to Mongo and not manage it with this module (because you're using managing it through Foreman/Katello as an example). In this case maybe all you want to do is:
```
  class {'mongodb::globals':
    manage_package_repo => false,
    manage_package      => false
  }

  mongodb_user { 'SOME_USER':
    ensure        => present,
    name          => 'SOME_USER',
    password_hash => mongodb_password('SOME_USER', 'SOME_USER'),
    database      => 'admin',
    roles         => ['root', 'admin'],
    tries         => 10
  }
```

Well and then you get `Empty host component parsing HostAndPort from ":27017"` and realize that all that's missing is just the bind_ip and that you don't want to do anything else with this module but add users... that's where this PR comes in!

This PR will add a default bind_ip of 127.0.0.1. This may be a poor hack because I don't know ruby from an implicit returning hole in the ground :) Either way, lets talk about it? maybe I'm doing something wrong? This PR seems reasonable however.