### PR TITLE
Reorder switches in dbpath_fix find command

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -136,7 +136,7 @@ class mongodb::server::config {
       exec { 'fix dbpath permissions':
         command   => "chown -R ${user}:${group} ${dbpath}",
         path      => ['/usr/bin', '/bin'],
-        onlyif    => "find ${dbpath} -print -not -user ${user} -o -not -group ${group} -quit | grep -q '.*'",
+        onlyif    => "find ${dbpath} -not -user ${user} -o -not -group ${group} -quit | grep -q '.*'",
         subscribe => File[$dbpath],
       }
     }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -136,7 +136,7 @@ class mongodb::server::config {
       exec { 'fix dbpath permissions':
         command   => "chown -R ${user}:${group} ${dbpath}",
         path      => ['/usr/bin', '/bin'],
-        onlyif    => "find ${dbpath} -not -user ${user} -o -not -group ${group} -print -quit | grep -q '.*'",
+        onlyif    => "find ${dbpath} -print -not -user ${user} -o -not -group ${group} -quit | grep -q '.*'",
         subscribe => File[$dbpath],
       }
     }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -280,7 +280,7 @@ describe 'mongodb::server' do
           is_expected.to contain_exec('fix dbpath permissions').
             with_command('chown -R foo:bar /var/lib/mongodb').
             with_path(['/usr/bin', '/bin']).
-            with_onlyif("find /var/lib/mongodb -print -not -user foo -o -not -group bar -quit | grep -q '.*'").
+            with_onlyif("find /var/lib/mongodb -not -user foo -o -not -group bar -quit | grep -q '.*'").
             that_subscribes_to('File[/var/lib/mongodb]')
         end
       end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -280,7 +280,7 @@ describe 'mongodb::server' do
           is_expected.to contain_exec('fix dbpath permissions').
             with_command('chown -R foo:bar /var/lib/mongodb').
             with_path(['/usr/bin', '/bin']).
-            with_onlyif("find /var/lib/mongodb -not -user foo -o -not -group bar -print -quit | grep -q '.*'").
+            with_onlyif("find /var/lib/mongodb -print -not -user foo -o -not -group bar -quit | grep -q '.*'").
             that_subscribes_to('File[/var/lib/mongodb]')
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description
Fix ordering of switches in `dbpath_fix`'s `find` command

#### This Pull Request (PR) fixes the following issues
Fixes #571
