### PR TITLE
fix(is_master-fact): use --ssl if --sslPEMKeyFile or --sslCAFile is s…

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -10,7 +10,11 @@ def get_options_from_hash_config(config)
   result = []
 
   result << "--port #{config['net.port']}" unless config['net.port'].nil?
-  result << "--ssl --host #{Facter.value(:fqdn)}" if config['net.ssl.mode'] == 'requireSSL'
+  # use --ssl and --host if:
+  # - sslMode is "requireSSL"
+  # - Parameter --sslPEMKeyFile is set
+  # - Parameter --sslCAFile is set
+  result << "--ssl --host #{Facter.value(:fqdn)}" if config['net.ssl.mode'] == 'requireSSL' || !config['net.ssl.PEMKeyFile'].nil? || !config['net.ssl.CAFile'].nil?
   result << "--sslPEMKeyFile #{config['net.ssl.PEMKeyFile']}" unless config['net.ssl.PEMKeyFile'].nil?
   result << "--sslCAFile #{config['net.ssl.CAFile']}" unless config['net.ssl.CAFile'].nil?
   result << '--ipv6' unless config['net.ipv6'].nil?
@@ -28,7 +32,11 @@ def get_options_from_keyvalue_config(file)
   result = []
 
   result << "--port #{config['port']}" unless config['port'].nil?
-  result << "--ssl --host #{Facter.value(:fqdn)}" if config['ssl'] == 'requireSSL'
+  # use --ssl and --host if:
+  # - sslMode is "requireSSL"
+  # - Parameter --sslPEMKeyFile is set
+  # - Parameter --sslCAFile is set
+  result << "--ssl --host #{Facter.value(:fqdn)}" if config['ssl'] == 'requireSSL' || !config['sslcert'].nil? || !config['sslca'].nil?
   result << "--sslPEMKeyFile #{config['sslcert']}" unless config['sslcert'].nil?
   result << "--sslCAFile #{config['sslca']}" unless config['sslca'].nil?
   result << '--ipv6' unless config['ipv6'].nil?

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -83,9 +83,9 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       first_ip_in_list = bindip.split(',').first
       ip_real = case first_ip_in_list
                 when '0.0.0.0'
-                  '127.0.0.1'
+                  Facter.value(:fqdn)
                 when %r{\[?::0\]?}
-                  '::1'
+                  Facter.value(:fqdn)
                 else
                   first_ip_in_list
                 end


### PR DESCRIPTION
#### Pull Request (PR) description
When using SSL in any other mode than requireSSL and you have specified a server or ca-certificate the mongodb_is_master fact will fail.

It will generate a shell command like "mongo --quiet --sslPEMKeyFile $file" which results in an
"Failed global initialization: BadValue ssl is required when ssl.PEMKeyFile is specified".

This pull-Request ensures that "--ssl" is also set when setting --sslPEMKeyFile or --sslCAFile.