### PR TITLE
Describe disabling logpath to make syslog work

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ textSearchEnabled=true). Default: None
 ##### `syslog`
 Sends all logging output to the host’s syslog system rather than to standard
 output or a log file. Default: None
-*Important*: You cannot use syslog with logpath.
+*Important*: You cannot use syslog with logpath. Set logpath to false to disable it.
 
 ##### `slave`
 Set to true to configure the current instance to act as slave instance in a


### PR DESCRIPTION
#### Pull Request (PR) description
I was confused about how to make the `syslog` config work because, even though I had not set `logpath`, the default value kept `syslog` from working. I tried setting it to an empty string, but that failed with a failed pattern check.

I had to look into the code to find out that I can also set it to `false` and that made it work.

#### This Pull Request (PR) fixes the following issues
n/a
