### PR TITLE
Add support for admin (create_admin) password hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,9 @@ Administrator user name
 ##### `admin_password`
 Administrator user password
 
+##### `admin_password_hash`
+Administrator user password in MD5 format
+
 ##### `admin_roles`
 Administrator user roles
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -76,7 +76,7 @@ class mongodb::server (
   Boolean $create_admin                                 = $mongodb::params::create_admin,
   String $admin_username                                = $mongodb::params::admin_username,
   Optional[String] $admin_password                      = undef,
-  String $admin_password_hash                           = undef,
+  Optional[String] $admin_password_hash                 = undef,
   Boolean $handle_creds                                 = $mongodb::params::handle_creds,
   Boolean $store_creds                                  = $mongodb::params::store_creds,
   Array $admin_roles                                    = $mongodb::params::admin_roles,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -100,20 +100,11 @@ class mongodb::server (
   }
 
   if $create_admin and ($service_ensure == 'running' or $service_ensure == true) {
-    if $admin_password {
-      mongodb::db { 'admin':
-        user     => $admin_username,
-        password => $admin_password,
-        roles    => $admin_roles,
-      }
-    } elsif $admin_password_hash {
-      mongodb::db { 'admin':
-        user          => $admin_username,
-        password_hash => $admin_password_hash,
-        roles         => $admin_roles,
-      }
-    } else {
-      fail('You did not specify a password or password hash for admin username')
+    mongodb::db { 'admin':
+      user          => $admin_username,
+      password      => $admin_password,
+      password_hash => $password_hash,
+      roles         => $admin_roles,
     }
 
     # Make sure it runs before other DB creation

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -76,6 +76,7 @@ class mongodb::server (
   Boolean $create_admin                                 = $mongodb::params::create_admin,
   String $admin_username                                = $mongodb::params::admin_username,
   Optional[String] $admin_password                      = undef,
+  String $admin_password_hash                           = undef,
   Boolean $handle_creds                                 = $mongodb::params::handle_creds,
   Boolean $store_creds                                  = $mongodb::params::store_creds,
   Array $admin_roles                                    = $mongodb::params::admin_roles,
@@ -99,10 +100,20 @@ class mongodb::server (
   }
 
   if $create_admin and ($service_ensure == 'running' or $service_ensure == true) {
-    mongodb::db { 'admin':
-      user     => $admin_username,
-      password => $admin_password,
-      roles    => $admin_roles,
+    if $admin_password {
+      mongodb::db { 'admin':
+        user     => $admin_username,
+        password => $admin_password,
+        roles    => $admin_roles,
+      }
+    } elsif $admin_password_hash {
+      mongodb::db { 'admin':
+        user          => $admin_username,
+        password_hash => $admin_password_hash,
+        roles         => $admin_roles,
+      }
+    } else {
+      fail('You did not specify a password or password hash for admin username')
     }
 
     # Make sure it runs before other DB creation

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -76,7 +76,7 @@ class mongodb::server (
   Boolean $create_admin                                 = $mongodb::params::create_admin,
   String $admin_username                                = $mongodb::params::admin_username,
   Optional[String] $admin_password                      = undef,
-  Optional[String] $admin_password_hash                 = undef,
+  Optional[String[1]] $admin_password_hash              = undef,
   Boolean $handle_creds                                 = $mongodb::params::handle_creds,
   Boolean $store_creds                                  = $mongodb::params::store_creds,
   Array $admin_roles                                    = $mongodb::params::admin_roles,


### PR DESCRIPTION
Added possibility to specify admin_password_hash when using the create_admin 
