### PR TITLE
Fix mongorc.js file when authentication is not enabled.

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -162,7 +162,7 @@ class mongodb::server::config {
 
   if $handle_creds {
     file { $rcfile:
-      ensure  => present,
+      ensure  => file,
       content => template('mongodb/mongorc.js.erb'),
       owner   => 'root',
       group   => 'root',

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -161,18 +161,12 @@ class mongodb::server::config {
   }
 
   if $handle_creds {
-    if $auth and $store_creds {
-      file { $rcfile:
-        ensure  => file,
-        content => template('mongodb/mongorc.js.erb'),
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0600',
-      }
-    } else {
-      file { $rcfile:
-        ensure => absent,
-      }
+    file { $rcfile:
+      ensure  => present,
+      content => template('mongodb/mongorc.js.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
     }
   }
 }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -56,7 +56,7 @@ describe 'mongodb::server' do
           it { is_expected.to contain_file(config_file).with_content(%r{^  fork: true$}) }
         end
 
-        it { is_expected.to contain_file('/root/.mongorc.js') }
+        it { is_expected.to contain_file('/root/.mongorc.js').with_ensure('file').without_content(%r{db\.auth}) }
         it { is_expected.not_to contain_exec('fix dbpath permissions') }
       end
 
@@ -252,7 +252,7 @@ describe 'mongodb::server' do
             }
           end
 
-          it { is_expected.to contain_file('/root/.mongorc.js') }
+          it { is_expected.to contain_file('/root/.mongorc.js').with_ensure('file').without_content(%r{db\.auth}) }
         end
       end
 

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -56,7 +56,7 @@ describe 'mongodb::server' do
           it { is_expected.to contain_file(config_file).with_content(%r{^  fork: true$}) }
         end
 
-        it { is_expected.to contain_file('/root/.mongorc.js').with_ensure('absent') }
+        it { is_expected.to contain_file('/root/.mongorc.js') }
         it { is_expected.not_to contain_exec('fix dbpath permissions') }
       end
 
@@ -252,7 +252,7 @@ describe 'mongodb::server' do
             }
           end
 
-          it { is_expected.to contain_file('/root/.mongorc.js').with_ensure('absent') }
+          it { is_expected.to contain_file('/root/.mongorc.js') }
         end
       end
 

--- a/templates/mongorc.js.erb
+++ b/templates/mongorc.js.erb
@@ -16,6 +16,7 @@ function rsReconfigSettings(settings){
   return rs.reconfig(cfg)
 }
 
+<% if @auth and @store_creds -%>
 function authRequired() {
   try {
     return db.serverCmdLineOpts().code == 13;
@@ -39,3 +40,4 @@ if (authRequired()) {
     abort('Unknown error')
   }
 }
+<% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
When mongodb auth is not enabled, puppet will crash if a RS member reconfiguration is needed since the mongorc.js file (that contains that function) is not created.

#### This Pull Request (PR) fixes the following issues
If the mongorc.js.erb is not created all the time, functions that are stored in it (like 'rsReconfigMember') can't be used by puppet if auth is not enabled.
Since manifests/server/config.pp will create the mongorc.js file all the time, the conditional for storing the credentials in the mongorc.js file are moved to templates/mongorc.js.erb .