### PR TITLE
Update mongodb-shard.conf.erb

### DIFF
--- a/spec/classes/mongos_spec.rb
+++ b/spec/classes/mongos_spec.rb
@@ -12,7 +12,7 @@ describe 'mongodb::mongos' do
           '/etc/mongodb-shard.conf'
         end
       end
-      
+
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }
 

--- a/spec/classes/mongos_spec.rb
+++ b/spec/classes/mongos_spec.rb
@@ -12,6 +12,16 @@ describe 'mongodb::mongos' do
           '/etc/mongodb-shard.conf'
         end
       end
+      
+      describe 'with specific bind_ip values' do
+        let :params do
+          {
+            bind_ip: ['127.0.0.1', '10.1.1.13']
+          }
+        end
+
+        it { is_expected.to contain_file(config_file).with_content(%r{^bind_ip = 127\.0\.0\.1\,10\.1\.1\.13$}) }
+      end
 
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }

--- a/spec/classes/mongos_spec.rb
+++ b/spec/classes/mongos_spec.rb
@@ -13,16 +13,6 @@ describe 'mongodb::mongos' do
         end
       end
       
-      describe 'with specific bind_ip values' do
-        let :params do
-          {
-            bind_ip: ['127.0.0.1', '10.1.1.13']
-          }
-        end
-
-        it { is_expected.to contain_file(config_file).with_content(%r{^bind_ip = 127\.0\.0\.1\,10\.1\.1\.13$}) }
-      end
-
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }
 
@@ -68,6 +58,16 @@ configdb = 127.0.0.1:27019
         end
 
         it { is_expected.to contain_service('mongos') }
+      end
+
+      describe 'with specific bind_ip values' do
+        let :params do
+          {
+            bind_ip: ['127.0.0.1', '10.1.1.13']
+          }
+        end
+
+        it { is_expected.to contain_file(config_file).with_content(%r{^bind_ip = 127\.0\.0\.1\,10\.1\.1\.13$}) }
       end
 
       context 'package_name => mongo-foo' do

--- a/templates/mongodb-shard.conf.erb
+++ b/templates/mongodb-shard.conf.erb
@@ -2,7 +2,7 @@
 configdb = <%= Array(@configdb).join(',') %>
 <% end -%>
 <% if @bind_ip -%>
-bind_ip = <%= @bind_ip %>
+bind_ip = <%= @bind_ip.join(',') %>
 <% end -%>
 <% if @port -%>
 port = <%= @port %>


### PR DESCRIPTION
fix the bind_ip usage in mongdb-shard.conf.erb, it is defined as array in manifests but config file wants it as a string ( comma separated list of ip adresses )

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
