### PR TITLE
Use rs.secondaryOk on versions that deprecated rs.slaveOk

### DIFF
--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -6,7 +6,9 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
 
   def self.instances
     require 'json'
-    dbs = JSON.parse mongo_eval('rs.slaveOk();printjson(db.getMongo().getDBs())')
+
+    pre_cmd = 'try { rs.secondaryOk() } catch (err) { rs.slaveOk() }'
+    dbs = JSON.parse mongo_eval(pre_cmd + ';printjson(db.getMongo().getDBs())')
 
     dbs['databases'].map do |db|
       new(name: db['name'],

--- a/spec/acceptance/replset_spec.rb
+++ b/spec/acceptance/replset_spec.rb
@@ -65,7 +65,7 @@ if hosts.length > 1
 
     it 'checks the data on the slave' do
       sleep(10)
-      on hosts_as('slave'), %{mongo --verbose --eval 'rs.slaveOk(); printjson(db.test.findOne({name:"test1"}))'} do |r|
+      on hosts_as('slave'), %{mongo --verbose --eval 'try { rs.secondaryOk() } catch (err) { rs.slaveOk() }; printjson(db.test.findOne({name:"test1"}))'} do |r|
         expect(r.stdout).to match %r{some value}
       end
     end
@@ -194,7 +194,7 @@ YXIsJ0gYcu9XG3mx10LbdPJvxSMg'
 
     it 'checks the data on the slave' do
       sleep(10)
-      on hosts_as('slave'), %{mongo test --verbose --eval 'load("/root/.mongorc.js");rs.slaveOk();printjson(db.dummyData.findOne())'} do |r|
+      on hosts_as('slave'), %{mongo test --verbose --eval 'load("/root/.mongorc.js");try { rs.secondaryOk() } catch (err) { rs.slaveOk() };printjson(db.dummyData.findOne())'} do |r|
         expect(r.stdout).to match %r{created_by_puppet}
       end
     end

--- a/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::Type.type(:mongodb_database).provider(:mongodb) do
     tmp = Tempfile.new('test')
     mongodconffile = tmp.path
     allow(provider.class).to receive(:mongod_conf_file).and_return(mongodconffile)
-    allow(provider.class).to receive(:mongo_eval).with('rs.slaveOk();printjson(db.getMongo().getDBs())').and_return(raw_dbs)
+    allow(provider.class).to receive(:mongo_eval).with('try { rs.secondaryOk() } catch (err) { rs.slaveOk() };printjson(db.getMongo().getDBs())').and_return(raw_dbs)
     allow(provider.class).to receive(:db_ismaster).and_return(true)
   end
 

--- a/templates/mongorc.js.erb
+++ b/templates/mongorc.js.erb
@@ -26,10 +26,16 @@ function authRequired() {
 }
 
 if (authRequired()) {
+  <%- if @replset -%>
+  // rs.slaveOk has been deprecated, use secondaryOk if available
   try {
-<% if @replset -%>
+    rs.secondaryOk()
+  }
+  catch (err) {
     rs.slaveOk()
-<% end -%>
+  }
+  <%- end -%>
+  try {
     var prev_db = db
     db = db.getSiblingDB('admin')
     db.auth('<%= @admin_username %>', '<%= @admin_password %>')


### PR DESCRIPTION
#### Pull Request (PR) description
rs.slaveOk has been deprecated since version 3.6.20 and others. Warnings are all over the place e.g.
in the mongodb_is_master fact. Which makes the fact and `/root/.mongrc.js` unusable.

Using a try-catch block to use the new command rs.secondaryOK() by default and fall back to rs.slaveOK() fixes this.