### PR TITLE
Use confine to check the existence of a command needed for the fact to resolve

### DIFF
--- a/lib/facter/mongodb_version.rb
+++ b/lib/facter/mongodb_version.rb
@@ -1,8 +1,8 @@
 Facter.add(:mongodb_version) do
+  confine { Facter::Core::Execution.which('mongo') }
+
   setcode do
-    if Facter::Core::Execution.which('mongo')
-      mongodb_version = Facter::Core::Execution.execute('mongo --version 2>&1')
-      %r{MongoDB shell version:?\s+v?([\w\.]+)}.match(mongodb_version)[1]
-    end
+    mongodb_version = Facter::Core::Execution.execute('mongo --version 2>&1')
+    %r{MongoDB shell version:?\s+v?([\w\.]+)}.match(mongodb_version)[1]
   end
 end


### PR DESCRIPTION
An initial puppet run (eg. in a vagrant box) will produce an error while trying to resolve the mongodb_version fact:
```
Facter: error while resolving custom fact "mongodb_version": undefined method '[]' for nil:NilClass
```
The reason is that the check for the existence of the mongo binary is inside the setcode block.

This pull request uses the fact confinement mechanism to pre-empt the fact resolution if the mongo binary is not available.

