### PR TITLE
Use Puppet-Datatype Sensitive for Passwords

### DIFF
--- a/lib/puppet/functions/mongodb_password.rb
+++ b/lib/puppet/functions/mongodb_password.rb
@@ -3,12 +3,19 @@ require_relative File.join('..', 'util', 'mongodb_md5er')
 # Get the mongodb password hash from the clear text password.
 Puppet::Functions.create_function(:mongodb_password) do
   dispatch :mongodb_password do
-    param 'String[1]', :username
-    param 'String[1]', :password
-    return_type 'String'
+    required_param 'String[1]', :username
+    required_param 'Variant[String[1], Sensitive[String[1]]]', :password
+    optional_param 'Boolean', :sensitive
+    return_type 'Variant[String, Sensitive[String]]'
   end
 
-  def mongodb_password(username, password)
-    Puppet::Util::MongodbMd5er.md5(username, password)
+  def mongodb_password(username, password, sensitive = false)
+    password = password.unwrap if password.respond_to?(:unwrap)
+    result_string = Puppet::Util::MongodbMd5er.md5(username, password)
+    if sensitive
+      Puppet::Pops::Types::PSensitiveType::Sensitive.new(result_string)
+    else
+      result_string
+    end
   end
 end

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -12,12 +12,12 @@
 #  tries (default: 10) - The maximum amount of two second tries to wait MongoDB startup.
 #
 define mongodb::db (
-  String           $user,
-  String           $db_name       = $name,
-  Optional[String] $password_hash = undef,
-  Optional[String] $password      = undef,
-  Array[String]    $roles         = ['dbAdmin'],
-  Integer[0]       $tries         = 10,
+  String                                             $user,
+  String                                             $db_name       = $name,
+  Optional[Variant[String[1], Sensitive[String[1]]]] $password_hash = undef,
+  Optional[Variant[String[1], Sensitive[String[1]]]] $password      = undef,
+  Array[String]                                      $roles         = ['dbAdmin'],
+  Integer[0]                                         $tries         = 10,
 ) {
   unless $facts['mongodb_is_master'] == 'false' { # lint:ignore:quoted_booleans
     mongodb_database { $db_name:
@@ -25,7 +25,9 @@ define mongodb::db (
       tries  => $tries,
     }
 
-    if $password_hash {
+    if $password_hash =~ Sensitive[String] {
+      $hash = $password_hash.unwrap
+    } elsif $password_hash {
       $hash = $password_hash
     } elsif $password {
       $hash = mongodb_password($user, $password)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -59,7 +59,7 @@ class mongodb::server (
   Optional[Boolean] $quiet                                      = undef,
   Optional[Integer] $slowms                                     = undef,
   Optional[Stdlib::Absolutepath] $keyfile                       = undef,
-  Optional[String[6]] $key                                      = undef,
+  Optional[Variant[String[6], Sensitive[String[6]]]] $key       = undef,
   Optional[Variant[String[1], Array[String[1]]]] $set_parameter = undef,
   Optional[Boolean] $syslog                                     = undef,
   $config_content                                               = undef,
@@ -75,7 +75,7 @@ class mongodb::server (
   Optional[String] $storage_engine                              = undef,
   Boolean $create_admin                                         = $mongodb::params::create_admin,
   String $admin_username                                        = $mongodb::params::admin_username,
-  Optional[String] $admin_password                              = undef,
+  Optional[Variant[String, Sensitive[String]]] $admin_password  = undef,
   Boolean $handle_creds                                         = $mongodb::params::handle_creds,
   Boolean $store_creds                                          = $mongodb::params::store_creds,
   Array $admin_roles                                            = $mongodb::params::admin_roles,
@@ -98,10 +98,15 @@ class mongodb::server (
     Class['mongodb::server::service'] -> Class['mongodb::server::config'] -> Class['mongodb::server::install']
   }
 
+  $admin_password_unsensitive = if $admin_password =~ Sensitive[String] {
+    $admin_password.unwrap
+  } else {
+    $admin_password
+  }
   if $create_admin and ($service_ensure == 'running' or $service_ensure == true) {
     mongodb::db { 'admin':
       user     => $admin_username,
-      password => $admin_password,
+      password => $admin_password_unsensitive,
       roles    => $admin_roles,
     }
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -160,6 +160,11 @@ class mongodb::server::config {
     }
   }
 
+  $admin_password_unsensitive = if $admin_password =~ Sensitive[String] {
+    $admin_password.unwrap
+  } else {
+    $admin_password
+  }
   if $handle_creds {
     file { $rcfile:
       ensure  => file,

--- a/spec/functions/mongodb_password_spec.rb
+++ b/spec/functions/mongodb_password_spec.rb
@@ -6,4 +6,7 @@ describe 'mongodb_password' do
   it { is_expected.to run.with_params(:undef, :undef).and_raise_error(ArgumentError) }
   it { is_expected.to run.with_params('', '').and_raise_error(ArgumentError) }
   it { is_expected.to run.with_params('user', 'pass').and_return('e0c4a7b97d4db31f5014e9694e567d6b') }
+  it { is_expected.to run.with_params('user', sensitive('pass')).and_return('e0c4a7b97d4db31f5014e9694e567d6b') }
+  it { is_expected.to run.with_params('user', sensitive('pass'), true) }
+  it { expect(subject.execute('user', sensitive('pass'), true).unwrap).to eq('e0c4a7b97d4db31f5014e9694e567d6b') }
 end

--- a/templates/mongorc.js.erb
+++ b/templates/mongorc.js.erb
@@ -38,7 +38,7 @@ if (authRequired()) {
   try {
     var prev_db = db
     db = db.getSiblingDB('admin')
-    db.auth('<%= @admin_username %>', '<%= @admin_password %>')
+    db.auth('<%= @admin_username %>', '<%= @admin_password_unsensitive %>')
     db = db.getSiblingDB(prev_db)
   }
   catch (err) {


### PR DESCRIPTION
- let Function mongodb_password() accept Parameter password of Datatype Sensitive
- add Parameter "sensitive" to Function mongodb_password to decide if its Returnvalue should be of Datatype Sensitive
- let defined Type mongodb::db accept Datatype Sensitive for $password_hash and $password
- let Class mongodb::server accept Datatype Sensitive for $key and $admin_password

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
