### PR TITLE
Replace slaveOK() with secondaryOk() to prevent Puppet manifest error…

### DIFF
--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
 
   def self.instances
     require 'json'
-    dbs = JSON.parse mongo_eval('rs.slaveOk();printjson(db.getMongo().getDBs())')
+    dbs = JSON.parse mongo_eval('rs.secondaryOk();printjson(db.getMongo().getDBs())')
 
     dbs['databases'].map do |db|
       new(name: db['name'],

--- a/spec/acceptance/replset_spec.rb
+++ b/spec/acceptance/replset_spec.rb
@@ -67,7 +67,7 @@ if hosts.length > 1
 
     it 'checks the data on the slave' do
       sleep(10)
-      on hosts_as('slave'), %{mongo --verbose --eval 'rs.slaveOk(); printjson(db.test.findOne({name:"test1"}))'} do |r|
+      on hosts_as('slave'), %{mongo --verbose --eval 'rs.secondaryOk(); printjson(db.test.findOne({name:"test1"}))'} do |r|
         expect(r.stdout).to match %r{some value}
       end
     end
@@ -198,7 +198,7 @@ YXIsJ0gYcu9XG3mx10LbdPJvxSMg'
 
     it 'checks the data on the slave' do
       sleep(10)
-      on hosts_as('slave'), %{mongo test --verbose --eval 'load("/root/.mongorc.js");rs.slaveOk();printjson(db.dummyData.findOne())'} do |r|
+      on hosts_as('slave'), %{mongo test --verbose --eval 'load("/root/.mongorc.js");rs.secondaryOk();printjson(db.dummyData.findOne())'} do |r|
         expect(r.stdout).to match %r{created_by_puppet}
       end
     end

--- a/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::Type.type(:mongodb_database).provider(:mongodb) do
     tmp = Tempfile.new('test')
     mongodconffile = tmp.path
     allow(provider.class).to receive(:mongod_conf_file).and_return(mongodconffile)
-    allow(provider.class).to receive(:mongo_eval).with('rs.slaveOk();printjson(db.getMongo().getDBs())').and_return(raw_dbs)
+    allow(provider.class).to receive(:mongo_eval).with('rs.secondaryOk();printjson(db.getMongo().getDBs())').and_return(raw_dbs)
     allow(provider.class).to receive(:db_ismaster).and_return(true)
   end
 

--- a/templates/mongorc.js.erb
+++ b/templates/mongorc.js.erb
@@ -27,7 +27,7 @@ function authRequired() {
 if (authRequired()) {
   try {
 <% if @replset -%>
-    rs.slaveOk()
+    rs.secondaryOk()
 <% end -%>
     var prev_db = db
     db = db.getSiblingDB('admin')


### PR DESCRIPTION
#### Pull Request (PR) description
Replace `rs.slaveOk()` with `rs.secondaryOk()` to prevent Puppet breaking errors.

#### This Pull Request (PR) fixes the following issues
Fixes #612 

