### PR TITLE
The 'password' attribute was constantly updated even when the password was not changed

### DIFF
--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -89,8 +89,15 @@ Puppet::Type.newtype(:mongodb_user) do
       @resource.provider.password_hash
     end
 
-    def insync?(_is)
-      should_to_s == to_s?
+    def insync?(is)
+      if is == :absent && @resource.provider.scram_credentials
+        scram = @resource.provider.scram_credentials
+        scram_util = Puppet::Util::MongodbScram.new(should_to_s, scram['salt'], scram['iterationCount'])
+        if scram['storedKey'] == scram_util.stored_key && scram['serverKey'] == scram_util.server_key
+          is = should_to_s
+        end
+      end
+      should_to_s == is
     end
   end
 


### PR DESCRIPTION

Example code:
```
mongodb_user { 'user':
  name          => 'user',
  ensure        => present,
  database      => 'test',
  password      => 'password',
  roles         => ['readWrite'],
  tries         => 10,
}
```
apply agent:
```
# created user
$ puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for mongo26-1
Info: Applying configuration version '1633423266'
Notice: /Stage[main]/Main/Node[mongo26-1]/Mongodb_user[user]/ensure: created
Notice: Applied catalog in 0.95 seconds
# password not changed, but:
$ puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for mongo26-1
Info: Applying configuration version '1633423278'
Notice: /Stage[main]/Main/Node[mongo26-1]/Mongodb_user[user]/password: defined 'password' as 3bcfc22a1cd6be41bc7814c13d3ce94c (corrective)
Notice: Applied catalog in 0.75 seconds
# password not changed, but:
$ puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for mongo26-1
Info: Applying configuration version '1633423289'
Notice: /Stage[main]/Main/Node[mongo26-1]/Mongodb_user[user]/password: defined 'password' as 3bcfc22a1cd6be41bc7814c13d3ce94c (corrective)
Notice: Applied catalog in 0.82 seconds
```
 As you can see, password is constantly being flagged as requiring changes. This PR fixes this behavior.
 
mongodb versions 4 and up use SCRAM-SHA-256 by default. This mechanism disallows the use of a password hash:
```
$ mongo test --quiet --host 127.0.0.1:27017 --eval "load('/root/.mongorc.js'); db.runCommand({\"createUser\":\"user\",\"pwd\":\"3bcfc22a1cd6be41bc7814c13d3ce94c\",\"roles\":[\"readWrite\"],\"digestPassword\":false})"
{
	"operationTime" : Timestamp(1633424331, 1),
	"ok" : 0,
	"errmsg" : "Use of SCRAM-SHA-256 requires undigested passwords",
	"code" : 2,
	"codeName" : "BadValue",
	"$clusterTime" : {
		"clusterTime" : Timestamp(1633424331, 1),
		"signature" : {
			"hash" : BinData(0,"phzg8Y9u+y3uMQL5IbE0z4DQa/c="),
			"keyId" : NumberLong("7015499301837078530")
		}
	}
}
```
Therefore, it makes sense to improve support for the 'password' attribute.
