### PR TITLE
Run apt update before installing package

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -17,7 +17,7 @@ class mongodb::repo::apt inherits mongodb::repo {
       },
     }
 
-    Apt::Source['mongodb'] -> Exec['apt_update'] -> Package<| tag == 'mongodb_package' |>
+    Apt::Source['mongodb'] -> Class['apt::update'] -> Package<| tag == 'mongodb_package' |>
   }
   else {
     apt::source { 'mongodb':


### PR DESCRIPTION
#### Pull Request (PR) description
On Ubuntu 20.04, the package repository is added, but the package itself fails to install because `apt-get update` was not run. If Puppet is run again on the machine, it does work the second time. 

This adds code to run `apt-get update` so that it works the first time.


#### This Pull Request (PR) fixes the following issues
Fixes #627 
