### PR TITLE
ReplicaSet with Auth creation

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -157,7 +157,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
           raise Puppet::Error, "Can't configure replicaset #{name}, host #{host} is not supposed to be part of a replicaset."
         end
 
-        if auth_enabled && status.key?('errmsg') && (status['errmsg'].include?('unauthorized') || status['errmsg'].include?('not authorized'))
+        if auth_enabled && status.key?('errmsg') && (status['errmsg'].include?('unauthorized') || status['errmsg'].include?('not authorized') || status['errmsg'].include?('requires authentication'))
           Puppet.warning "Host #{host} is available, but you are unauthorized because of authentication is enabled: #{auth_enabled}"
           alive.push(member)
         end


### PR DESCRIPTION
fix: replset with auth returns "requires authentication" message when checking replicaset members

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

```
mongodb::globals::version: 4.4.10
mongodb::server::port: 27017
mongodb::server::bind_ip:
  - 0.0.0.0
mongodb::server::auth: true
mongodb::server::store_creds: true
mongodb::server::handle_creds: true
mongodb::server::create_admin: true
mongodb::server::admin_password: admin

mongodb::server::keyfile: /etc/mongodb.key
mongodb::server::key: |
  Z17Lor65VIgRCGClC3IZhXJe34fPM2Xa7lrzZdV35PDjP4cm6Vt7rP9jSQsxZBY2
  UXGOIFNzQ+IOsU/bP9EUmfXqFWEJcjdXw9AfaEU+630XwmYRFnzQ3AEwxLqAgSVN
  47DXoZNh7lFu7VJanhupzPwkgpsgqgpBC9HaJCDe0Pxx5AenrxWdSwRkmzrG5tEL
  JJXxdCWPGVCYp6YXzdTuHzJ2Ff/Ph2yhDxNlxNHFcgeuFGVnPe5TsjFEqzsYxjNI
  8q75LSwN+D9L9yPLAPwV3l70mKbKncp8RP/NlR3dScQpuS0P/PhkWkYs2hQVFAOu
  O52UOiwKti4Zaio3K2ZVIN2PlFQ8m2H5VMijkI6CQE5iGWieui/eJCtakauEuOXk
  NHHJ0DseSWNEapz5QE+lpWicDLb8maz9Gon3WEEDhcCt68MyA+/0HhoOgomhoEOj
  /R5Did6BvJpiYsVhbKakiFauDZlsXM710kSHtxs2IYXj+PBa7FMDr4rgLk4eqU5e
  ZY6LsFvVxgi+qNSsIdXtEpWOHjeiHTFucE8/mKDE8cKeRjQfaJYOgFIHLCIZLvkF
  T9QEbd1+0WRkXpOBzBsPr106s+M9IDMcGeaD8rk3NY8AitmRkKHdXVtt2Mm5HSXP
  CpQLg0vUcqe37TqUy0FomeSu95DXO0Ud7lKO7I/PPwkxaACfU9lr0uQm0gOV4EMW
  hzxqMUZUHpMz+CMh9AWsZWcaWLr/rpxeLb2/mO8+kzoRgRNCLBOD/l5QjBkqxKpr
  CdhRRBdgV/ZMFE6+vy2VtN8Be2gweTiKhS9lMUTHD3gjEOCgGfyN6v1eZDCjJG9h
  2Wuk63L2NIHFENaq5Cf4IIPTYweMfrYG1OnRVfkvstFUxlBqnMQAjPrM/YbITvpI
  29MN4jnLWVkqmy8dLszrlAiT70bT2dGnAbyefGr0UhHHxVXfP75K2mPITKrMvMot
  YsfL9ZkOH+WOYIAhF7VaEfV8KigEHbc/Er8vI3PTE5+Cxrxu

mongodb::server::replset: myrs
mongodb::server::replset_config:
  myrs:
    ensure: present
    members:
      - host: mongo-03:27017
        priority: 3
      - host: mongo-02:27017
        priority: 2
      - host: mongo-01:27017
        priority: 1
```

I'm using full Hiera config but this was not working because Mongo is giving `"errmsg": "command replSetGetStatus requires authentication"` which was not included in the auth condition.

Tested on Debian 10 with Mongo 4.4.10

#### This Pull Request (PR) fixes the following issues

n/a
