### PR TITLE
Do not manage the repository on RedHat when manage_package_repo is set to false

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -45,15 +45,19 @@ class mongodb::globals (
   # Setup of the repo only makes sense globally, so we are doing it here.
   case $facts['os']['family'] {
     'RedHat', 'Linux', 'Suse': {
-      class { 'mongodb::repo':
-        ensure              => present,
-        version             => pick($version, '3.6'),
-        use_enterprise_repo => $use_enterprise_repo,
-        repo_location       => $repo_location,
-        proxy               => $repo_proxy,
+      # For RedHat, Linux and Suse family: if manage_package_repo is set at undef that include mongodb::repo
+      if $manage_package_repo != false {
+        class { 'mongodb::repo':
+          ensure              => present,
+          version             => pick($version, '3.6'),
+          use_enterprise_repo => $use_enterprise_repo,
+          repo_location       => $repo_location,
+          proxy               => $repo_proxy,
+        }
       }
     }
     default: {
+      # For other (Debian) family: if manage_package_repo is set at undef that not include mongodb::repo
       if $manage_package_repo {
         if $use_enterprise_repo == true and $version == undef {
           fail('You must set mongodb::globals::version when mongodb::globals::use_enterprise_repo is true')

--- a/spec/classes/globals_spec.rb
+++ b/spec/classes/globals_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'mongodb::globals' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      if facts[:os]['family'] == 'Debian' && facts[:os]['release']['major'] != '10'
+        it { is_expected.not_to contain_class('mongodb::repo') }
+      else
+        it { is_expected.to contain_class('mongodb::repo') }
+      end
+
+      context 'with manage_package_repo at false' do
+        let(:params) do
+          { manage_package_repo: false }
+        end
+
+        it { is_expected.not_to contain_class('mongodb::repo') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Hello,

For os family not equal to `Debian`, when you set `manage_package_repo` at false, that include `mongodb::repo` 

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes #636