### PR TITLE
SCRAM-SHA-256 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
-    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
+    "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "apt": "https://github.com/puppetlabs/puppetlabs-apt.git"
     "systemd": "https://github.com/voxpupuli/puppet-systemd.git"
     "zypprepo": "https://github.com/voxpupuli/puppet-zypprepo.git"
     yumrepo_core:

--- a/README.md
+++ b/README.md
@@ -566,6 +566,11 @@ Administrator authentication mechanism.
 scram_sha_256 password synchronization verification is not supported.
 Default: 'scram_sha_1'
 
+##### `admin_update_password`
+Update password.
+Used with SCRAM-SHA-256 because password verification is not supported.
+Default: false
+
 ##### `admin_roles`
 Administrator user roles
 
@@ -658,6 +663,11 @@ Authentication mechanism.
 Can be either 'scram_sha_1' or 'scram_sha_256'.
 scram_sha_256 password synchronization verification is not supported.
 Default: 'scram_sha_1'
+
+##### `update_password`
+Update password.
+Used with SCRAM-SHA-256 because password verification is not supported.
+Default: false
 
 ##### `roles`
 Array with user roles as string.

--- a/README.md
+++ b/README.md
@@ -561,6 +561,11 @@ Administrator user name
 ##### `admin_password`
 Administrator user password
 
+##### `admin_auth_mechanism`
+Administrator authentication mechanism.
+scram_sha_256 password synchronization verification is not supported.
+Default: 'scram_sha_1'
+
 ##### `admin_roles`
 Administrator user roles
 
@@ -647,6 +652,12 @@ For more information please refer to [MongoDB Authentication Process](http://doc
 
 ##### `password`
 Plain-text user password (will be hashed)
+
+##### `auth_mechanism`
+Authentication mechanism.
+Can be either 'scram_sha_1' or 'scram_sha_256'.
+scram_sha_256 password synchronization verification is not supported.
+Default: 'scram_sha_1'
 
 ##### `roles`
 Array with user roles as string.

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -53,7 +53,7 @@ Puppet::Type.newtype(:mongodb_user) do
   end
 
   newproperty(:password_hash) do
-    desc 'The password hash of the user. Use mongodb_password() for creating hash. Only available on MongoDB 3.0 and later.'
+    desc 'The password hash of the user. Use mongodb_password() for creating hash. Only available on MongoDB 3.0 and later. SCRAM-SHA-256 authentication mechanism is not supported.'
     defaultto do
       if @resource[:password].nil?
         raise Puppet::Error, "Property 'password_hash' must be set. Use mongodb_password() for creating hash." if provider.database == :absent
@@ -90,8 +90,16 @@ Puppet::Type.newtype(:mongodb_user) do
     end
 
     def insync?(_is)
+      return true if @resource[:auth_mechanism] == :scram_sha_256
+
       should_to_s == to_s?
     end
+  end
+
+  newparam(:auth_mechanism) do
+    desc 'Authentication mechanism. Password verification is not supported with SCRAM-SHA-256.'
+    defaultto :scram_sha_1
+    newvalues(:scram_sha_256, :scram_sha_1)
   end
 
   newproperty(:scram_credentials) do
@@ -115,6 +123,8 @@ Puppet::Type.newtype(:mongodb_user) do
       err("Either 'password_hash' or 'password' should be provided")
     elsif !self[:password_hash].nil? && !self[:password].nil?
       err("Only one of 'password_hash' or 'password' should be provided")
+    elsif !self[:password_hash].nil? && self[:auth_mechanism] == :scram_sha_256
+      err("'password_hash' is not supported with SCRAM-SHA-256 authentication mechanism")
     end
     if should(:scram_credentials)
       raise("The parameter 'scram_credentials' is read-only and cannot be changed")

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -90,7 +90,7 @@ Puppet::Type.newtype(:mongodb_user) do
     end
 
     def insync?(_is)
-      return true if @resource[:auth_mechanism] == :scram_sha_256
+      return !@resource[:update_password] if @resource[:auth_mechanism] == :scram_sha_256
 
       should_to_s == to_s?
     end
@@ -100,6 +100,11 @@ Puppet::Type.newtype(:mongodb_user) do
     desc 'Authentication mechanism. Password verification is not supported with SCRAM-SHA-256.'
     defaultto :scram_sha_1
     newvalues(:scram_sha_256, :scram_sha_1)
+  end
+
+  newparam(:update_password, boolean: true) do
+    desc 'Update password. Used with SCRAM-SHA-256 because password verification is not supported.'
+    defaultto false
   end
 
   newproperty(:scram_credentials) do

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -5,6 +5,7 @@
 # == Parameters
 #
 #  user - Database username.
+#  auth_mechanism - Authentication mechanism. scram_sha_256 password verification is not supported. Defaults to 'scram_sha_1'.
 #  db_name - Database name. Defaults to $name.
 #  password_hash - Hashed password. Hex encoded md5 hash of "$username:mongo:$password".
 #  password - Plain text user password. This is UNSAFE, use 'password_hash' instead.
@@ -13,11 +14,12 @@
 #
 define mongodb::db (
   String                                             $user,
-  String                                             $db_name       = $name,
-  Optional[Variant[String[1], Sensitive[String[1]]]] $password_hash = undef,
-  Optional[Variant[String[1], Sensitive[String[1]]]] $password      = undef,
-  Array[String]                                      $roles         = ['dbAdmin'],
-  Integer[0]                                         $tries         = 10,
+  Enum['scram_sha_1', 'scram_sha_256']               $auth_mechanism = 'scram_sha_1',
+  String                                             $db_name        = $name,
+  Optional[Variant[String[1], Sensitive[String[1]]]] $password_hash  = undef,
+  Optional[Variant[String[1], Sensitive[String[1]]]] $password       = undef,
+  Array[String]                                      $roles          = ['dbAdmin'],
+  Integer[0]                                         $tries          = 10,
 ) {
   unless $facts['mongodb_is_master'] == 'false' { # lint:ignore:quoted_booleans
     mongodb_database { $db_name:
@@ -35,12 +37,23 @@ define mongodb::db (
       fail("Parameter 'password_hash' or 'password' should be provided to mongodb::db.")
     }
 
+    if $auth_mechanism == 'scram_sha_256' {
+      $password_config = {
+        password => $password,
+      }
+    } else {
+      $password_config = {
+        password_hash => $hash,
+      }
+    }
+
     mongodb_user { "User ${user} on db ${db_name}":
-      ensure        => present,
-      password_hash => $hash,
-      username      => $user,
-      database      => $db_name,
-      roles         => $roles,
+      ensure         => present,
+      username       => $user,
+      database       => $db_name,
+      roles          => $roles,
+      auth_mechanism => $auth_mechanism,
+      *              => $password_config,
     }
   }
 }

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -11,15 +11,17 @@
 #  password - Plain text user password. This is UNSAFE, use 'password_hash' instead.
 #  roles (default: ['dbAdmin']) - array with user roles.
 #  tries (default: 10) - The maximum amount of two second tries to wait MongoDB startup.
+#  update_password (default: false) - Force an update of the password when scram_sha_256 is used.
 #
 define mongodb::db (
   String                                             $user,
-  Enum['scram_sha_1', 'scram_sha_256']               $auth_mechanism = 'scram_sha_1',
-  String                                             $db_name        = $name,
-  Optional[Variant[String[1], Sensitive[String[1]]]] $password_hash  = undef,
-  Optional[Variant[String[1], Sensitive[String[1]]]] $password       = undef,
-  Array[String]                                      $roles          = ['dbAdmin'],
-  Integer[0]                                         $tries          = 10,
+  Enum['scram_sha_1', 'scram_sha_256']               $auth_mechanism  = 'scram_sha_1',
+  String                                             $db_name         = $name,
+  Optional[Variant[String[1], Sensitive[String[1]]]] $password_hash   = undef,
+  Optional[Variant[String[1], Sensitive[String[1]]]] $password        = undef,
+  Array[String]                                      $roles           = ['dbAdmin'],
+  Integer[0]                                         $tries           = 10,
+  Boolean                                            $update_password = false,
 ) {
   unless $facts['mongodb_is_master'] == 'false' { # lint:ignore:quoted_booleans
     mongodb_database { $db_name:
@@ -39,7 +41,8 @@ define mongodb::db (
 
     if $auth_mechanism == 'scram_sha_256' {
       $password_config = {
-        password => $password,
+        password        => $password,
+        update_password => $update_password,
       }
     } else {
       $password_config = {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class mongodb::params inherits mongodb::globals {
   $restart               = true
   $create_admin          = false
   $admin_username        = 'admin'
+  $admin_auth_mechanism  = 'scram_sha_1'
   $admin_roles           = [
     'userAdmin', 'readWrite', 'dbAdmin', 'dbAdminAnyDatabase', 'readAnyDatabase',
     'readWriteAnyDatabase', 'userAdminAnyDatabase', 'clusterAdmin',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -77,6 +77,7 @@ class mongodb::server (
   String $admin_username                                        = $mongodb::params::admin_username,
   Optional[Variant[String, Sensitive[String]]] $admin_password  = undef,
   Enum['scram_sha_1', 'scram_sha_256'] $admin_auth_mechanism    = $mongodb::params::admin_auth_mechanism,
+  Boolean $admin_update_password                                = false,
   Boolean $handle_creds                                         = $mongodb::params::handle_creds,
   Boolean $store_creds                                          = $mongodb::params::store_creds,
   Array $admin_roles                                            = $mongodb::params::admin_roles,
@@ -106,10 +107,11 @@ class mongodb::server (
   }
   if $create_admin and ($service_ensure == 'running' or $service_ensure == true) {
     mongodb::db { 'admin':
-      user           => $admin_username,
-      auth_mechanism => $admin_auth_mechanism,
-      password       => $admin_password_unsensitive,
-      roles          => $admin_roles,
+      user            => $admin_username,
+      auth_mechanism  => $admin_auth_mechanism,
+      password        => $admin_password_unsensitive,
+      roles           => $admin_roles,
+      update_password => $admin_update_password,
     }
 
     # Make sure it runs before other DB creation

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -76,6 +76,7 @@ class mongodb::server (
   Boolean $create_admin                                         = $mongodb::params::create_admin,
   String $admin_username                                        = $mongodb::params::admin_username,
   Optional[Variant[String, Sensitive[String]]] $admin_password  = undef,
+  Enum['scram_sha_1', 'scram_sha_256'] $admin_auth_mechanism    = $mongodb::params::admin_auth_mechanism,
   Boolean $handle_creds                                         = $mongodb::params::handle_creds,
   Boolean $store_creds                                          = $mongodb::params::store_creds,
   Array $admin_roles                                            = $mongodb::params::admin_roles,
@@ -105,9 +106,10 @@ class mongodb::server (
   }
   if $create_admin and ($service_ensure == 'running' or $service_ensure == true) {
     mongodb::db { 'admin':
-      user     => $admin_username,
-      password => $admin_password_unsensitive,
-      roles    => $admin_roles,
+      user           => $admin_username,
+      auth_mechanism => $admin_auth_mechanism,
+      password       => $admin_password_unsensitive,
+      roles          => $admin_roles,
     }
 
     # Make sure it runs before other DB creation

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -54,9 +54,9 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
       cmd_json = <<-EOS.gsub(%r{^\s*}, '').gsub(%r{$\n}, '')
       {
         "createUser":"new_user",
-        "pwd":"pass",
         "customData":{"createdBy":"Puppet Mongodb_user['new_user']"},
         "roles":[{"role":"role1","db":"new_database"},{"role":"role2","db":"other_database"}],
+        "pwd":"pass",
         "digestPassword":false
       }
       EOS


### PR DESCRIPTION
#### Pull Request (PR) description
 
Add limited support for SCRAM-SHA-256 authentication mechanism.

Limited because we loose the ability to check if the password is insync when SCRAM-SHA-256 is used.
The password is no longer digested on the client.

The second commit add the possibility to force the update of the password manually with a boolean.

#### This Pull Request (PR) fixes the following issues

Fixes #597
