### PR TITLE
mongodb_user ignores `database` parameter when removing a user

### DIFF
--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -89,7 +89,7 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
   end
 
   def destroy
-    mongo_eval("db.dropUser(#{@resource[:username].to_json})")
+    mongo_eval("db.dropUser(#{@resource[:username].to_json})", @resource[:database])
   end
 
   def exists?

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -24,6 +24,29 @@ describe 'mongodb_database' do
         expect(r.stdout.chomp).to eq('1')
       end
     end
+
+    it 'removes a user with no errors' do
+      pp = <<-EOS
+        class { 'mongodb::server': }
+        -> class { 'mongodb::client': }
+        -> mongodb_database { 'testdb': ensure => present }
+        ->
+        mongodb_user {'testuser':
+          ensure        => absent,
+          password_hash => mongodb_password('testuser', 'passw0rd'),
+          database      => 'testdb',
+        }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'auth should fail' do
+      shell("mongo testdb --quiet --eval 'db.auth(\"testuser\",\"passw0rd\")'") do |r|
+        expect(r.stdout.chomp).to contain('Error: Authentication failed')
+      end
+    end
   end
 
   context 'with custom port' do

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -69,7 +69,7 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'destroy' do
     it 'removes a user' do
-      allow(provider).to receive(:mongo_eval).with('db.dropUser("new_user")')
+      allow(provider).to receive(:mongo_eval).with('db.dropUser("new_user")', 'new_database')
       provider.destroy
       expect(provider).to have_received(:mongo_eval)
     end


### PR DESCRIPTION
#### Pull Request (PR) description
Currently setting `ensure => absent` for a user doesn't work for users created in other databases than `admin`

#### This Pull Request (PR) fixes the following issues

This PR fixes this by passing the database value to `mongo_eval`