### PR TITLE
Fix password changing for SHA-1 mechanism #649

### DIFF
--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -103,7 +103,7 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, parent: Puppet::Provider::Mon
         pwd: @resource[:password_hash],
         digestPassword: false
       }
-      command[:mechanisms] = ['SCRAM-SHA-1']
+      command[:mechanisms] = @resource[:auth_mechanism] == :scram_sha_1 ? ['SCRAM-SHA-1'] : ['SCRAM-SHA-256']
 
       mongo_eval("db.runCommand(#{command.to_json})", @resource[:database])
     else

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -93,7 +93,8 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
       {
           "updateUser":"new_user",
           "pwd":"pass",
-          "digestPassword":false
+          "digestPassword":false,
+          "mechanisms":["SCRAM-SHA-1"]
       }
       EOS
       allow(provider).to receive(:mongo_eval).


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Added the mechanism parameter for the password_hash command
```
 def password_hash=(_value)
    if db_ismaster
      command = {
        updateUser: @resource[:username],
        pwd: @resource[:password_hash],
        digestPassword: false
      }
      command[:mechanisms] = @resource[:auth_mechanism] == :scram_sha_1 ? ['SCRAM-SHA-1'] : ['SCRAM-SHA-256']

      mongo_eval("db.runCommand(#{command.to_json})", @resource[:database])
    else
      Puppet.warning 'User password operations are available only from master host'
    end
  end
```

Changed unit test for mongodb_user due to new expected line generated for password_hash command.

#### This Pull Request (PR) fixes the following issues
Fixes #649

