### PR TITLE
draft: add x509 auth for admin user using mongosh

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -6,7 +6,23 @@ def mongod_conf_file
   locations.find { |location| File.exist? location }
 end
 
+def mongosh_conf_file
+  '/root/.mongosh.yaml' if File.exist?('/root/mongosh.yaml')
+end
+
 def get_options_from_hash_config(config)
+  # read also the mongoshrc.yaml yaml file, to retrieve the admins certkey file
+  if mongosh_conf_file
+    mongosh_config = YAML.load_file(mongosh_conf_file)
+    # check which tlscert we need to use
+    _tlscert = if config['setParameter'] && config['setParameter']['authenticationMechanisms'] == 'MONGODB-X509' &&
+                  mongosh_config['admin'] && mongosh_config['admin']['tlsCertificateKeyFile']
+                 mongosh_config['admin']['tlsCertificateKeyFile']
+               end
+  else
+    _tlscert = config['net.tls.certificateKeyFile']
+  end
+
   result = []
 
   result << "--port #{config['net.port']}" unless config['net.port'].nil?
@@ -21,15 +37,21 @@ def get_options_from_hash_config(config)
   # - tlsMode is "requireTLS"
   # - Parameter --tlsCertificateKeyFile is set
   # - Parameter --tlsCAFile is set
-  result << "--tls --host #{Facter.value(:fqdn)}" if config['net.tls.mode'] == 'requireTLS' || !config['net.tls.certificateKeyFile'].nil? || !config['net.tls.CAFile'].nil?
-  result << "--tlsCertificateKeyFile #{config['net.tls.certificateKeyFile']}" unless config['net.tls.certificateKeyFile'].nil?
+  result << "--tls --host #{Facter.value(:fqdn)}" if config['net.tls.mode'] == 'requireTLS' || !_tlscert.nil? || !config['net.tls.CAFile'].nil?
+  result << "--tlsCertificateKeyFile #{_tlscert}" unless _tlscert.nil?
   result << "--tlsCAFile #{config['net.tls.CAFile']}" unless config['net.tls.CAFile'].nil?
+
+  # use --authenticationMechanism, ---authenticationDatabase
+  # when
+  # - authenticationMechanism MONGODB-X509
+  result << "--authenticationDatabase '$external' --authenticationMechanism MONGODB-X509" unless config['setParameter'].nil? || config['setParameter']['authenticationMechanisms'] != 'MONGODB-X509'
 
   result << '--ipv6' unless config['net.ipv6'].nil?
 
   result.join(' ')
 end
 
+# I think we can get rid of this ?
 def get_options_from_keyvalue_config(file)
   config = {}
   File.readlines(file).map do |line|
@@ -72,16 +94,19 @@ end
 Facter.add('mongodb_is_master') do
   setcode do
     if %w[mongo mongod].all? { |m| Facter::Util::Resolution.which m }
+      # if we have a mongod_conf_file we use mongosh, else stick to mongo
+      # this will only work for < 6.x versions
       file = mongod_conf_file
       if file
         options = get_options_from_config(file)
-        e = File.exist?('/root/.mongorc.js') ? 'load(\'/root/.mongorc.js\'); ' : ''
+        e = File.exist?('/root/.mongoshrc.js') ? 'load(\'/root/.mongoshrc.js\'); ' : ''
 
         # Check if the mongodb server is responding:
-        Facter::Core::Execution.exec("mongo --quiet #{options} --eval \"#{e}printjson(db.adminCommand({ ping: 1 }))\"")
+        Facter::Core::Execution.exec("mongosh --quiet #{options} --eval \"#{e}printjson(db.adminCommand({ ping: 1 }))\"")
 
         if $CHILD_STATUS.success?
-          Facter::Core::Execution.exec("mongo --quiet #{options} --eval \"#{e}db.isMaster().ismaster\"")
+          # TODO: need to catch errors like 'Error: Authentication failed.' ?
+          Facter::Core::Execution.exec("mongosh --quiet #{options} --eval \"#{e}db.isMaster().ismaster\"")
         else
           'not_responding'
         end

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -30,6 +30,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
 
   def self.instances
     instance = replset_properties
+    Puppet.debug("In replset.instances with #{instance}")
     if instance
       # There can only be one replset per node
       [new(instance)]
@@ -39,6 +40,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
   end
 
   def self.prefetch(resources)
+    Puppet.debug("In replset.prefetch")
     instances.each do |prov|
       resource = resources[prov.name]
       resource.provider = prov if resource
@@ -147,6 +149,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
   end
 
   def get_hosts_status(members)
+    Puppet.debug("In get_hosts_status")
     alive = []
     members.select do |member|
       begin
@@ -189,6 +192,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
   end
 
   def get_members_changes(current_members_conf, new_members_conf)
+    Puppet.debug("In get_members_changes")
     # no changes in members config
     return [[], [], []] if new_members_conf.nil?
 
@@ -284,7 +288,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
             Puppet.debug 'Replica set initialization has successfully ended'
             return true
           else
-            Puppet.debug "Wainting for replica initialization. Retry: #{n}"
+            Puppet.debug "Waiting for replica initialization. Retry: #{n}"
             sleep retry_sleep
             next
           end
@@ -388,7 +392,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
 
   def self.mongo_command(command, host = nil, retries = 4)
     begin
-      output = mongo_eval("printjson(#{command})", 'admin', retries, host)
+      output = mongo_eval("EJSON.stringify(#{command})", 'admin', retries, host)
     rescue Puppet::ExecutionFailure => e
       Puppet.debug "Got an exception: #{e}"
       raise

--- a/lib/puppet/type/mongodb_replset.rb
+++ b/lib/puppet/type/mongodb_replset.rb
@@ -30,6 +30,7 @@ Puppet::Type.newtype(:mongodb_replset) do
     desc 'The replicaSet settings config'
 
     def insync?(is)
+      Puppet.debug("in type replset attribute settings with #{is}")
       should.each do |k, v|
         if v != is[k]
           Puppet.debug 'The replicaset settings config is not insync'
@@ -50,6 +51,7 @@ Puppet::Type.newtype(:mongodb_replset) do
 
     # check if is different
     def insync?(is)
+      Puppet.debug("in type replset attribute members #{is}")
       sync = true
       current = is.clone
       should.each do |sm|

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -55,7 +55,7 @@ Puppet::Type.newtype(:mongodb_user) do
   newproperty(:password_hash) do
     desc 'The password hash of the user. Use mongodb_password() for creating hash. Only available on MongoDB 3.0 and later. SCRAM-SHA-256 authentication mechanism is not supported.'
     defaultto do
-      if @resource[:password].nil?
+      if @resource[:auth_mechanism] != :x509 && @resource[:password].nil?
         raise Puppet::Error, "Property 'password_hash' must be set. Use mongodb_password() for creating hash." if provider.database == :absent
       end
     end
@@ -99,7 +99,7 @@ Puppet::Type.newtype(:mongodb_user) do
   newparam(:auth_mechanism) do
     desc 'Authentication mechanism. Password verification is not supported with SCRAM-SHA-256.'
     defaultto :scram_sha_1
-    newvalues(:scram_sha_256, :scram_sha_1)
+    newvalues(:scram_sha_256, :scram_sha_1, :x509)
   end
 
   newparam(:update_password, boolean: true) do
@@ -124,12 +124,14 @@ Puppet::Type.newtype(:mongodb_user) do
   end
 
   validate do
-    if self[:password_hash].nil? && self[:password].nil? && provider.password.nil? && provider.password_hash.nil?
-      err("Either 'password_hash' or 'password' should be provided")
-    elsif !self[:password_hash].nil? && !self[:password].nil?
-      err("Only one of 'password_hash' or 'password' should be provided")
-    elsif !self[:password_hash].nil? && self[:auth_mechanism] == :scram_sha_256
-      err("'password_hash' is not supported with SCRAM-SHA-256 authentication mechanism")
+    if self[:auth_mechanism] != :x509
+      if self[:password_hash].nil? && self[:password].nil? && provider.password.nil? && provider.password_hash.nil?
+        err("Either 'password_hash' or 'password' should be provided")
+      elsif !self[:password_hash].nil? && !self[:password].nil?
+        err("Only one of 'password_hash' or 'password' should be provided")
+      elsif !self[:password_hash].nil? && self[:auth_mechanism] == :scram_sha_256
+        err("'password_hash' is not supported with SCRAM-SHA-256 authentication mechanism")
+      end
     end
     if should(:scram_credentials)
       raise("The parameter 'scram_credentials' is read-only and cannot be changed")

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -15,7 +15,7 @@
 #
 define mongodb::db (
   String                                             $user,
-  Enum['scram_sha_1', 'scram_sha_256']               $auth_mechanism  = 'scram_sha_1',
+  Enum['scram_sha_1', 'scram_sha_256', 'x509']       $auth_mechanism  = 'scram_sha_1',
   String                                             $db_name         = $name,
   Optional[Variant[String[1], Sensitive[String[1]]]] $password_hash   = undef,
   Optional[Variant[String[1], Sensitive[String[1]]]] $password        = undef,
@@ -29,25 +29,29 @@ define mongodb::db (
       tries  => $tries,
     }
 
-    if $password_hash =~ Sensitive[String] {
-      $hash = $password_hash.unwrap
-    } elsif $password_hash {
-      $hash = $password_hash
-    } elsif $password {
-      $hash = mongodb_password($user, $password)
-    } else {
-      fail("Parameter 'password_hash' or 'password' should be provided to mongodb::db.")
-    }
+    if $auth_mechanism != 'x509' {
+      if $password_hash =~ Sensitive[String] {
+        $hash = $password_hash.unwrap
+      } elsif $password_hash {
+        $hash = $password_hash
+      } elsif $password {
+        $hash = mongodb_password($user, $password)
+      } else {
+        fail("Parameter 'password_hash' or 'password' should be provided to mongodb::db.")
+      }
 
-    if $auth_mechanism == 'scram_sha_256' {
-      $password_config = {
-        password        => $password,
-        update_password => $update_password,
+      if $auth_mechanism == 'scram_sha_256' {
+        $password_config = {
+          password        => $password,
+          update_password => $update_password,
+        }
+      } else {
+        $password_config = {
+          password_hash => $hash,
+        }
       }
     } else {
-      $password_config = {
-        password_hash => $hash,
-      }
+      $password_config = {}
     }
 
     mongodb_user { "User ${user} on db ${db_name}":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class mongodb::params inherits mongodb::globals {
   ]
   $handle_creds          = true
   $store_creds           = false
-  $rcfile                = "${facts['root_home']}/.mongorc.js"
+  $rcfile                = "${facts['root_home']}/.mongoshrc.js"
   $dbpath_fix            = false
 
   $manage_package        = pick($mongodb::globals::manage_package, $mongodb::globals::manage_package_repo, false)
@@ -37,6 +37,8 @@ class mongodb::params inherits mongodb::globals {
     $package_ensure        = true
     $package_ensure_mongos = true
   }
+
+  $mongosh_package_name    = 'mongodb-mongosh'
 
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $facts['os']['family'] {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,78 +1,80 @@
 # PRIVATE CLASS: do not call directly
 class mongodb::server::config {
-  $ensure           = $mongodb::server::ensure
-  $user             = $mongodb::server::user
-  $group            = $mongodb::server::group
-  $config           = $mongodb::server::config
-  $config_content   = $mongodb::server::config_content
-  $config_template  = $mongodb::server::config_template
-  $config_data      = $mongodb::server::config_data
-  $dbpath           = $mongodb::server::dbpath
-  $dbpath_fix       = $mongodb::server::dbpath_fix
-  $pidfilepath      = $mongodb::server::pidfilepath
-  $pidfilemode      = $mongodb::server::pidfilemode
-  $manage_pidfile   = $mongodb::server::manage_pidfile
-  $logpath          = $mongodb::server::logpath
-  $logappend        = $mongodb::server::logappend
-  $system_logrotate = $mongodb::server::system_logrotate
-  $fork             = $mongodb::server::fork
-  $port             = $mongodb::server::port
-  $journal          = $mongodb::server::journal
-  $nojournal        = $mongodb::server::nojournal
-  $smallfiles       = $mongodb::server::smallfiles
-  $cpu              = $mongodb::server::cpu
-  $auth             = $mongodb::server::auth
-  $noath            = $mongodb::server::noauth
-  $create_admin     = $mongodb::server::create_admin
-  $admin_username   = $mongodb::server::admin_username
-  $admin_password   = $mongodb::server::admin_password
-  $handle_creds     = $mongodb::server::handle_creds
-  $store_creds      = $mongodb::server::store_creds
-  $rcfile           = $mongodb::server::rcfile
-  $verbose          = $mongodb::server::verbose
-  $verbositylevel   = $mongodb::server::verbositylevel
-  $objcheck         = $mongodb::server::objcheck
-  $quota            = $mongodb::server::quota
-  $quotafiles       = $mongodb::server::quotafiles
-  $diaglog          = $mongodb::server::diaglog
-  $oplog_size       = $mongodb::server::oplog_size
-  $nohints          = $mongodb::server::nohints
-  $nohttpinterface  = $mongodb::server::nohttpinterface
-  $noscripting      = $mongodb::server::noscripting
-  $notablescan      = $mongodb::server::notablescan
-  $noprealloc       = $mongodb::server::noprealloc
-  $nssize           = $mongodb::server::nssize
-  $mms_token        = $mongodb::server::mms_token
-  $mms_name         = $mongodb::server::mms_name
-  $mms_interval     = $mongodb::server::mms_interval
-  $configsvr        = $mongodb::server::configsvr
-  $shardsvr         = $mongodb::server::shardsvr
-  $replset          = $mongodb::server::replset
-  $rest             = $mongodb::server::rest
-  $quiet            = $mongodb::server::quiet
-  $slowms           = $mongodb::server::slowms
-  $keyfile          = $mongodb::server::keyfile
-  $key              = $mongodb::server::key
-  $ipv6             = $mongodb::server::ipv6
-  $bind_ip          = $mongodb::server::bind_ip
-  $directoryperdb   = $mongodb::server::directoryperdb
-  $profile          = $mongodb::server::profile
-  $maxconns         = $mongodb::server::maxconns
-  $set_parameter    = $mongodb::server::set_parameter
-  $syslog           = $mongodb::server::syslog
-  $ssl              = $mongodb::server::ssl
-  $ssl_key          = $mongodb::server::ssl_key
-  $ssl_ca           = $mongodb::server::ssl_ca
-  $ssl_weak_cert    = $mongodb::server::ssl_weak_cert
+  $ensure                = $mongodb::server::ensure
+  $user                  = $mongodb::server::user
+  $group                 = $mongodb::server::group
+  $config                = $mongodb::server::config
+  $config_content        = $mongodb::server::config_content
+  $config_template       = $mongodb::server::config_template
+  $config_data           = $mongodb::server::config_data
+  $dbpath                = $mongodb::server::dbpath
+  $dbpath_fix            = $mongodb::server::dbpath_fix
+  $pidfilepath           = $mongodb::server::pidfilepath
+  $pidfilemode           = $mongodb::server::pidfilemode
+  $manage_pidfile        = $mongodb::server::manage_pidfile
+  $logpath               = $mongodb::server::logpath
+  $logappend             = $mongodb::server::logappend
+  $system_logrotate      = $mongodb::server::system_logrotate
+  $fork                  = $mongodb::server::fork
+  $port                  = $mongodb::server::port
+  $journal               = $mongodb::server::journal
+  $nojournal             = $mongodb::server::nojournal
+  $smallfiles            = $mongodb::server::smallfiles
+  $cpu                   = $mongodb::server::cpu
+  $auth                  = $mongodb::server::auth
+  $noath                 = $mongodb::server::noauth
+  $create_admin          = $mongodb::server::create_admin
+  $admin_username        = $mongodb::server::admin_username
+  $admin_password        = $mongodb::server::admin_password
+  $admin_auth_mechanism  = $mongodb::server::admin_auth_mechanism
+  $admin_tls_key         = $mongodb::server::admin_tls_key
+  $handle_creds          = $mongodb::server::handle_creds
+  $store_creds           = $mongodb::server::store_creds
+  $rcfile                = $mongodb::server::rcfile
+  $verbose               = $mongodb::server::verbose
+  $verbositylevel        = $mongodb::server::verbositylevel
+  $objcheck              = $mongodb::server::objcheck
+  $quota                 = $mongodb::server::quota
+  $quotafiles            = $mongodb::server::quotafiles
+  $diaglog               = $mongodb::server::diaglog
+  $oplog_size            = $mongodb::server::oplog_size
+  $nohints               = $mongodb::server::nohints
+  $nohttpinterface       = $mongodb::server::nohttpinterface
+  $noscripting           = $mongodb::server::noscripting
+  $notablescan           = $mongodb::server::notablescan
+  $noprealloc            = $mongodb::server::noprealloc
+  $nssize                = $mongodb::server::nssize
+  $mms_token             = $mongodb::server::mms_token
+  $mms_name              = $mongodb::server::mms_name
+  $mms_interval          = $mongodb::server::mms_interval
+  $configsvr             = $mongodb::server::configsvr
+  $shardsvr              = $mongodb::server::shardsvr
+  $replset               = $mongodb::server::replset
+  $rest                  = $mongodb::server::rest
+  $quiet                 = $mongodb::server::quiet
+  $slowms                = $mongodb::server::slowms
+  $keyfile               = $mongodb::server::keyfile
+  $key                   = $mongodb::server::key
+  $ipv6                  = $mongodb::server::ipv6
+  $bind_ip               = $mongodb::server::bind_ip
+  $directoryperdb        = $mongodb::server::directoryperdb
+  $profile               = $mongodb::server::profile
+  $maxconns              = $mongodb::server::maxconns
+  $set_parameter         = $mongodb::server::set_parameter
+  $syslog                = $mongodb::server::syslog
+  $ssl                   = $mongodb::server::ssl
+  $ssl_key               = $mongodb::server::ssl_key
+  $ssl_ca                = $mongodb::server::ssl_ca
+  $ssl_weak_cert         = $mongodb::server::ssl_weak_cert
   $ssl_invalid_hostnames = $mongodb::server::ssl_invalid_hostnames
-  $ssl_mode         = $mongodb::server::ssl_mode
-  $tls              = $mongodb::server::tls
-  $tls_key          = $mongodb::server::tls_key
-  $tls_ca           = $mongodb::server::tls_ca
+  $ssl_mode              = $mongodb::server::ssl_mode
+  $tls                   = $mongodb::server::tls
+  $tls_key               = $mongodb::server::tls_key
+  $tls_ca                = $mongodb::server::tls_ca
   $tls_conn_without_cert = $mongodb::server::tls_conn_without_cert
   $tls_invalid_hostnames = $mongodb::server::tls_invalid_hostnames
-  $tls_mode         = $mongodb::server::tls_mode
-  $storage_engine   = $mongodb::server::storage_engine
+  $tls_mode              = $mongodb::server::tls_mode
+  $storage_engine        = $mongodb::server::storage_engine
 
   File {
     owner => $user,
@@ -126,6 +128,20 @@ class mongodb::server::config {
       mode    => '0644',
     }
 
+    # TODO: we kind of use this file to force x509 autehntication in the providers when it exsists
+    #       Open for suugestions how to deal with this
+    if $admin_auth_mechanism == 'x509' {
+      $_ensure = 'present'
+    } else {
+      $_ensure = 'absent'
+    }
+
+    file { '/root/.mongosh.yaml':
+      ensure  => $_ensure,
+      mode    => '0400',
+      content => "---\n${admin_username}:\n  tlsCertificateKeyFile: ${admin_tls_key}",
+    }
+
     file { $dbpath:
       ensure   => directory,
       mode     => '0750',
@@ -176,7 +192,7 @@ class mongodb::server::config {
   if $handle_creds {
     file { $rcfile:
       ensure  => file,
-      content => template('mongodb/mongorc.js.erb'),
+      content => template('mongodb/mongoshrc.js.erb'),
       owner   => 'root',
       group   => 'root',
       mode    => '0600',

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -33,4 +33,10 @@ class mongodb::server::install {
       tag    => 'mongodb_package',
     }
   }
+
+  if $mongodb::server::admin_auth_mechanism == 'x509' {
+    package { $mongodb::server::mongosh_package_name:
+      ensure => present,
+    }
+  }
 }

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -169,6 +169,13 @@ setParameter:
   <%= v %>
 <% end -%>
 <% end -%>
+<% if @admin_auth_mechanism == 'x509' -%>
+<%# setParameters.auth... gives an error on startup status=2/INVALIDARGUMENT -%>
+<% if !@set_parameter -%>
+setParameter:
+<% end -%>
+  authenticationMechanisms: MONGODB-X509
+<% end -%>
 
 <% if @config_data -%>
 <% @config_data.each do |k,v| -%>

--- a/templates/mongoshrc.js.erb
+++ b/templates/mongoshrc.js.erb
@@ -1,4 +1,3 @@
-<%# TODO: clean this up in the manifest ? (kind of supporting upgrad to momgosh only ? -%>
 function rsReconfigMember(member){
   var cfg = rs.config()
   cfg.members.forEach(function(part,index,memberArray){
@@ -20,14 +19,29 @@ function rsReconfigSettings(settings){
 <% if @auth and @store_creds -%>
 function authRequired() {
   try {
-    return db.serverCmdLineOpts().code == 13;
-  } catch (err) {
+    db.serverCmdLineOpts();
     return false;
+  } catch (err) {
+    return true;
   }
 }
 
 if (authRequired()) {
   <%- if @replset -%>
+    <%- if @admin_auth_mechanism == 'x509' -%>
+  db.getMongo().setReadPref()
+  try {
+    db.getSiblingDB('$external').auth(
+      {
+        mechanism: 'MONGODB-X509'
+      }
+    )
+  }
+  catch (err) {
+    // This isn't catching authentication errors as I'd expect...
+    abort('Unknown error')
+  }
+   <%- else -%>
   // rs.slaveOk has been deprecated, use secondaryOk if available
   try {
     rs.secondaryOk()
@@ -35,7 +49,6 @@ if (authRequired()) {
   catch (err) {
     rs.slaveOk()
   }
-  <%- end -%>
   try {
     var prev_db = db
     db = db.getSiblingDB('admin')
@@ -46,5 +59,7 @@ if (authRequired()) {
     // This isn't catching authentication errors as I'd expect...
     abort('Unknown error')
   }
+    <% end -%>
+  <% end -%>
 }
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
This PR is a work in progress.  
* adds x509 auth_mechanism for the admin user
* replaces mongo with mongosh, mainly using x509 authentication (for now)

It works for me in a already running setup, which I'm upgrading from 4.x to 6.x.

Setting up proper test nodes to keep supporting all versions supporting mongosh.

Not planning to stay compatible with mongo command, since its gone in 6.x

#### This Pull Request (PR) try to fix the following issues
Fixes #648
Fixes #642

will be very please with loads of comments and how to proceed with this.

(and need to do some work on the tests still )