### PR TITLE
Make pidfilepath depend on global manage_pidfile

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,7 +47,9 @@ class mongodb::params inherits mongodb::globals {
 
       $service_name = pick($mongodb::globals::service_name, 'mongod')
       $logpath      = '/var/log/mongodb/mongod.log'
-      $pidfilepath  = '/var/run/mongodb/mongod.pid'
+      if $manage_pidfile {
+        $pidfilepath  = '/var/run/mongodb/mongod.pid'
+      }
       $config       = '/etc/mongod.conf'
       $fork         = true
       $journal      = true


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add a switch to the pidfilepath, making it undef if the global manage_pidfile is set to false. This avoid having the pidFilePath populated in the mongo.conf when there is no need for a PID file. Actually prevents mongo to start on RHEL after a reboot of the host.


#### This Pull Request (PR) fixes the following issues
<!--

-->
