### PR TITLE
Remove extra line causing errors: "Started a new thread for the timer service"

### DIFF
--- a/lib/puppet/util/mongodb_output.rb
+++ b/lib/puppet/util/mongodb_output.rb
@@ -11,6 +11,7 @@ module Puppet
         data.gsub!(%r{^Error:.+}, '')
         data.gsub!(%r{^.*warning:.+}, '') # remove warnings if sslAllowInvalidHostnames is true
         data.gsub!(%r{^.*The server certificate does not match the host name.+}, '') # remove warnings if sslAllowInvalidHostnames is true mongo 3.x
+        data.gsub!(%r{^.*Started a new thread for the timer service.+}, '') # Started a new thread for the timer service mongo 5.x (SERVER-78540)
         data
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
- remove fist line of mongo output if it contains `Started a new thread for the timer service` this is an as of yet unpatched bug in mongo 5.x (mongo 4.x and 6.x) have already received backports 5.x unfortunately has not. 

#### This Pull Request (PR) fixes the following issues
Fixes #680 
