### PR TITLE
Drop pidfile_workaround from Beaker testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,3 @@ jobs:
   puppet:
     name: Puppet
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
-    with:
-      pidfile_workaround: 'CentOS,Ubuntu'

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,5 +1,3 @@
 ---
 appveyor.yml:
   delete: true
-.github/workflows/ci.yml:
-  pidfile_workaround: CentOS,Ubuntu


### PR DESCRIPTION
To see if it's indeed no longer a problem, as suggested in https://github.com/voxpupuli/puppet_metadata/pull/103.