### PR TITLE
Fix CONTRIBUTING documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -131,19 +131,29 @@ You can install all needed gems for spec tests into the modules directory by
 running:
 
 ```sh
-bundle install --path .vendor/ --without development system_tests release --jobs "$(nproc)"
+bundle config set --local path '.vendor/'
+bundle config set --local without 'development system_tests release'
+bundle install --jobs "$(nproc)"
 ```
 
 If you also want to run acceptance tests:
 
 ```sh
-bundle install --path .vendor/ --with system_tests --without development release --jobs "$(nproc)"
+bundle config set --local path '.vendor/'
+bundle config set --local without 'development release'
+bundle config set --local with 'system_tests'
+bundle install --jobs "$(nproc)"
 ```
 
 Our all in one solution if you don't know if you need to install or update gems:
 
 ```sh
-bundle install --path .vendor/ --with system_tests --without development release --jobs "$(nproc)"; bundle update; bundle clean
+bundle config set --local path '.vendor/'
+bundle config set --local without 'development release'
+bundle config set --local with 'system_tests'
+bundle install --jobs "$(nproc)"
+bundle update
+bundle clean
 ```
 
 As an alternative to the `--jobs "$(nproc)` parameter, you can set an

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -163,6 +163,11 @@ environment variable:
 BUNDLE_JOBS="$(nproc)"
 ```
 
+Prepare to run tests:
+```sh
+bundle exec rake spec_prep
+```
+
 ### Note for OS X users
 
 `nproc` isn't a valid command under OS x. As an alternative, you can do:


### PR DESCRIPTION
This PR updates the `CONTRIBUTING.md` file so given commands are actually valid and tests can be run.
The bundler commands given contained deprecated arguments that no longer worked.