### PR TITLE
Use mongodb repo by default; require repo version >= 4.4

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -98,6 +98,7 @@ The following parameters are available in the `mongodb::globals` class:
 * [`ipv6`](#-mongodb--globals--ipv6)
 * [`bind_ip`](#-mongodb--globals--bind_ip)
 * [`version`](#-mongodb--globals--version)
+* [`repo_version`](#-mongodb--globals--repo_version)
 * [`manage_package_repo`](#-mongodb--globals--manage_package_repo)
 * [`manage_package`](#-mongodb--globals--manage_package)
 * [`repo_proxy`](#-mongodb--globals--repo_proxy)
@@ -213,13 +214,21 @@ Version of mongodb to install
 
 Default value: `undef`
 
+##### <a name="-mongodb--globals--repo_version"></a>`repo_version`
+
+Data type: `String[1]`
+
+Version of mongodb repo to install
+
+Default value: `'5.0'`
+
 ##### <a name="-mongodb--globals--manage_package_repo"></a>`manage_package_repo`
 
-Data type: `Optional[Boolean]`
+Data type: `Boolean`
 
 If `true` configure upstream mongodb repos
 
-Default value: `undef`
+Default value: `true`
 
 ##### <a name="-mongodb--globals--manage_package"></a>`manage_package`
 

--- a/data/Debian-10.yaml
+++ b/data/Debian-10.yaml
@@ -1,3 +1,0 @@
----
-mongodb::globals::version: '4.4.29'          # Debian 10 doesn't provide mongodb 3.6.
-mongodb::globals::manage_package_repo: true  # Debian 10 doesn't provide mongodb packages. So manage it!

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -13,6 +13,7 @@
 # @param ipv6
 # @param bind_ip
 # @param version Version of mongodb to install
+# @param repo_version Version of mongodb repo to install
 # @param manage_package_repo If `true` configure upstream mongodb repos
 # @param manage_package
 # @param repo_proxy
@@ -25,33 +26,34 @@
 # @param manage_pidfile
 #
 class mongodb::globals (
-  $server_package_name                   = undef,
-  $client_package_name                   = undef,
+  $server_package_name         = undef,
+  $client_package_name         = undef,
 
-  $mongod_service_manage                 = undef,
-  $service_enable                        = undef,
-  $service_ensure                        = undef,
-  $service_name                          = undef,
-  $service_provider                      = undef,
-  $service_status                        = undef,
+  $mongod_service_manage       = undef,
+  $service_enable              = undef,
+  $service_ensure              = undef,
+  $service_name                = undef,
+  $service_provider            = undef,
+  $service_status              = undef,
 
-  $user                                  = undef,
-  $group                                 = undef,
-  $ipv6                                  = undef,
-  $bind_ip                               = undef,
-  Optional[String[1]] $version           = undef,
-  Optional[Boolean] $manage_package_repo = undef,
-  $manage_package                        = undef,
-  $repo_proxy                            = undef,
-  $proxy_username                        = undef,
-  $proxy_password                        = undef,
+  $user                        = undef,
+  $group                       = undef,
+  $ipv6                        = undef,
+  $bind_ip                     = undef,
+  Optional[String[1]] $version = undef,
+  String[1] $repo_version      = '5.0',
+  Boolean $manage_package_repo = true,
+  $manage_package              = undef,
+  $repo_proxy                  = undef,
+  $proxy_username              = undef,
+  $proxy_password              = undef,
 
-  $repo_location                         = undef,
-  $use_enterprise_repo                   = undef,
+  $repo_location               = undef,
+  $use_enterprise_repo         = undef,
 
-  $pidfilepath                           = undef,
-  $pidfilemode                           = undef,
-  $manage_pidfile                        = undef,
+  $pidfilepath                 = undef,
+  $pidfilemode                 = undef,
+  $manage_pidfile              = undef,
 ) {
   if $use_enterprise_repo {
     $edition = 'enterprise'
@@ -60,24 +62,10 @@ class mongodb::globals (
   }
 
   # Setup of the repo only makes sense globally, so we are doing it here.
-  if $manage_package_repo or $manage_package_repo == undef and $facts['os']['family'] in ['RedHat','Linux','Suse'] {
-    if $use_enterprise_repo == true and $version == undef {
-      fail('You must set mongodb::globals::version when mongodb::globals::use_enterprise_repo is true')
-    }
-
-    # Set some default working repositories per OS if no version
-    # specified.
-    $_repo_version = $version ? {
-      Undef   => $facts['os']['family'] in ['RedHat', 'Linux', 'Suse'] ? {
-        true    => '4.4',
-        default => $version,
-      },
-      default => $version,
-    }
-
+  if $manage_package_repo {
     class { 'mongodb::repo':
       ensure              => present,
-      version             => $_repo_version,
+      version             => $repo_version,
       use_enterprise_repo => $use_enterprise_repo,
       repo_location       => $repo_location,
       proxy               => $repo_proxy,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -15,29 +15,36 @@
 # @param aptkey_options
 #
 class mongodb::repo (
-  Variant[Enum['present', 'absent'], Boolean] $ensure = 'present',
-  Optional[String] $version                           = undef,
-  Boolean $use_enterprise_repo                        = false,
-  Optional[String] $repo_location                     = undef,
-  Optional[String] $proxy                             = undef,
-  Optional[String] $proxy_username                    = undef,
-  Optional[String] $proxy_password                    = undef,
-  Optional[String[1]] $aptkey_options                 = undef,
+  Enum['present', 'absent'] $ensure   = 'present',
+  Optional[String] $version           = undef,
+  Boolean $use_enterprise_repo        = false,
+  Optional[String] $repo_location     = undef,
+  Optional[String] $proxy             = undef,
+  Optional[String] $proxy_username    = undef,
+  Optional[String] $proxy_password    = undef,
+  Optional[String[1]] $aptkey_options = undef,
 ) {
+  if $version == undef and $repo_location == undef {
+    fail('`version` or `repo_location` is required')
+  }
+  if $version != undef and $repo_location != undef {
+    fail('`version` is not supported with `repo_location`')
+  }
+  if $version != undef and versioncmp($version, '4.4') < 0 {
+    fail('Package repositories for versions older than 4.4 are unsupported')
+  }
+
   case $facts['os']['family'] {
     'RedHat', 'Linux': {
       if $repo_location != undef {
         $location = $repo_location
         $description = 'MongoDB Custom Repository'
-      } elsif $version == undef or versioncmp($version, '3.0.0') < 0 {
-        fail('Package repositories for versions older than 3.0 are unsupported')
       } else {
-        $mongover = split($version, '[.]')
         if $use_enterprise_repo {
-          $location = "https://repo.mongodb.com/yum/redhat/\$releasever/mongodb-enterprise/${mongover[0]}.${mongover[1]}/\$basearch/"
+          $location = "https://repo.mongodb.com/yum/redhat/\$releasever/mongodb-enterprise/${version}/\$basearch/"
           $description = 'MongoDB Enterprise Repository'
         } else {
-          $location = "https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/${mongover[0]}.${mongover[1]}/\$basearch/"
+          $location = "https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/${version}/\$basearch/"
           $description = 'MongoDB Repository'
         }
       }
@@ -49,11 +56,8 @@ class mongodb::repo (
       if $repo_location {
         $location = $repo_location
         $description = 'MongoDB Custom Repository'
-      } elsif $version == undef or versioncmp($version, '3.2.0') < 0 {
-        fail('Package repositories for versions older than 3.2 are unsupported')
       } else {
-        $mongover = split($version, '[.]')
-        $location = "https://repo.mongodb.org/zypper/suse/\$releasever_major/mongodb-org/${mongover[0]}.${mongover[1]}/\$basearch/"
+        $location = "https://repo.mongodb.org/zypper/suse/\$releasever_major/mongodb-org/${version}/\$basearch/"
         $description = 'MongoDB Repository'
       }
 
@@ -63,8 +67,6 @@ class mongodb::repo (
     'Debian': {
       if $repo_location != undef {
         $location = $repo_location
-      } elsif $version == undef or versioncmp($version, '3.0.0') < 0 {
-        fail('Package repositories for versions older than 3.0 are unsupported')
       } else {
         if $use_enterprise_repo == true {
           $repo_domain = 'repo.mongodb.com'
@@ -74,27 +76,21 @@ class mongodb::repo (
           $repo_path   = 'mongodb-org'
         }
 
-        $mongover = split($version, '[.]')
         $location = $facts['os']['name'] ? {
           'Debian' => "https://${repo_domain}/apt/debian",
           'Ubuntu' => "https://${repo_domain}/apt/ubuntu",
           default  => undef
         }
-        $release     = "${facts['os']['distro']['codename']}/${repo_path}/${mongover[0]}.${mongover[1]}"
+        $release     = "${facts['os']['distro']['codename']}/${repo_path}/${version}"
         $repos       = $facts['os']['name'] ? {
           'Debian' => 'main',
           'Ubuntu' => 'multiverse',
           default => undef
         }
-        $key = "${mongover[0]}.${mongover[1]}" ? {
+        $key = $version ? {
           '5.0'   => 'F5679A222C647C87527C2F8CB00A0BD1E2C63C11',
           '4.4'   => '20691EEC35216C63CAF66CE1656408E390CFB1F5',
-          '4.2'   => 'E162F504A20CDF15827F718D4B7C549A058F8B6B',
-          '4.0'   => '9DA31620334BD75D9DCB49F368818C72E52529D4',
-          '3.6'   => '2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5',
-          '3.4'   => '0C49F3730359A14518585931BC711F9BA15703C6',
-          '3.2'   => '42F3E95A2C4F08279C4960ADD68FA50FEA312927',
-          default => '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10'
+          default => '20691EEC35216C63CAF66CE1656408E390CFB1F5'
         }
         $key_server = 'hkp://keyserver.ubuntu.com:80'
       }
@@ -103,7 +99,7 @@ class mongodb::repo (
     }
 
     default: {
-      if($ensure == 'present' or $ensure == true) {
+      if($ensure == 'present') {
         fail("Unsupported managed repository for osfamily: ${facts['os']['family']}, operatingsystem: ${facts['os']['name']}, module ${module_name} currently only supports managing repos for osfamily RedHat, Suse, Debian and Ubuntu")
       }
     }

--- a/spec/acceptance/mongos_spec.rb
+++ b/spec/acceptance/mongos_spec.rb
@@ -3,16 +3,7 @@
 require 'spec_helper_acceptance'
 
 describe 'mongodb::mongos class' do
-  package_name = case fact('osfamily')
-                 when 'Debian'
-                   if fact('os.distro.codename') =~ %r{^(buster|bullseye)$}
-                     'mongodb-org-server'
-                   else
-                     'mongodb-server'
-                   end
-                 else
-                   'mongodb-org-server'
-                 end
+  package_name = 'mongodb-org-server'
   config_file = '/etc/mongos.conf'
 
   describe 'installation' do

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -3,28 +3,9 @@
 require 'spec_helper_acceptance'
 
 describe 'mongodb::server class' do
-  case fact('osfamily')
-  when 'Debian'
-    config_file = if fact('os.distro.codename') =~ %r{^(buster)$}
-                    '/etc/mongod.conf'
-                  else
-                    '/etc/mongodb.conf'
-                  end
-    service_name = if fact('os.distro.codename') =~ %r{^(buster)$}
-                     'mongod'
-                   else
-                     'mongodb'
-                   end
-    package_name = if fact('os.distro.codename') =~ %r{^(buster)$}
-                     'mongodb-org-server'
-                   else
-                     'mongodb-server'
-                   end
-  else
-    config_file = '/etc/mongod.conf'
-    service_name = 'mongod'
-    package_name = 'mongodb-org-server'
-  end
+  config_file = '/etc/mongod.conf'
+  service_name = 'mongod'
+  package_name = 'mongodb-org-server'
 
   describe 'installation' do
     it 'works with no errors' do

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -9,26 +9,16 @@ describe 'mongodb::client' do
 
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }
-
-        if facts[:os]['release']['major'] =~ %r{(10)}
-          it { is_expected.to create_package('mongodb_client').with_ensure('4.4.29') }
-        else
-          it { is_expected.to create_package('mongodb_client').with_ensure('present') }
-        end
+        it { is_expected.to create_package('mongodb_client').with_ensure('present').with_name('mongodb-org-shell').with_tag('mongodb_package') }
       end
 
-      context 'with manage_package' do
+      context 'with manage_package_repo set to false' do
         let(:pre_condition) do
-          "class { 'mongodb::globals': manage_package => true }"
+          "class { 'mongodb::globals': manage_package_repo => false }"
         end
 
         it { is_expected.to compile.with_all_deps }
-
-        if facts[:os]['release']['major'] =~ %r{(10)}
-          it { is_expected.to create_package('mongodb_client').with_ensure('4.4.29').with_name('mongodb-org-shell').with_tag('mongodb_package') }
-        else
-          it { is_expected.to create_package('mongodb_client').with_ensure('present').with_name('mongodb-org-shell').with_tag('mongodb_package') }
-        end
+        it { is_expected.to create_package('mongodb_client').with_ensure('present') }
       end
     end
   end

--- a/spec/classes/globals_spec.rb
+++ b/spec/classes/globals_spec.rb
@@ -7,11 +7,7 @@ describe 'mongodb::globals' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      if facts[:os]['family'] == 'Debian' && facts[:os]['release']['major'] != '10'
-        it { is_expected.not_to contain_class('mongodb::repo') }
-      else
-        it { is_expected.to contain_class('mongodb::repo') }
-      end
+      it { is_expected.to contain_class('mongodb::repo') }
 
       context 'with manage_package_repo at false' do
         let(:params) do

--- a/spec/classes/mongos_spec.rb
+++ b/spec/classes/mongos_spec.rb
@@ -7,17 +7,8 @@ describe 'mongodb::mongos' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      package_name = case facts[:os]['family']
-                     when 'Debian'
-                       if facts[:os]['release']['major'] =~ %r{(10)}
-                         'mongodb-org-mongos'
-                       else
-                         'mongodb-server'
-                       end
-                     else
-                       'mongodb-org-mongos'
-                     end
-      config_file = '/etc/mongos.conf'
+      package_name = 'mongodb-org-mongos'
+      config_file  = '/etc/mongos.conf'
 
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }
@@ -25,11 +16,7 @@ describe 'mongodb::mongos' do
         # install
         it { is_expected.to contain_class('mongodb::mongos::install') }
 
-        if facts[:os]['release']['major'] =~ %r{(10)}
-          it { is_expected.to contain_package('mongodb_mongos').with_ensure('4.4.29').with_name(package_name).with_tag('mongodb_package') }
-        else
-          it { is_expected.to contain_package('mongodb_mongos').with_ensure('present').with_name(package_name).with_tag('mongodb_package') }
-        end
+        it { is_expected.to contain_package('mongodb_mongos').with_ensure('present').with_name(package_name).with_tag('mongodb_package') }
 
         # config
         it { is_expected.to contain_class('mongodb::mongos::config') }
@@ -66,12 +53,7 @@ describe 'mongodb::mongos' do
         end
 
         it { is_expected.to compile.with_all_deps }
-
-        if facts[:os]['release']['major'] =~ %r{(10)}
-          it { is_expected.to contain_package('mongodb_mongos').with_name('mongo-foo').with_ensure('4.4.29').with_tag('mongodb_package') }
-        else
-          it { is_expected.to contain_package('mongodb_mongos').with_name('mongo-foo').with_ensure('present').with_tag('mongodb_package') }
-        end
+        it { is_expected.to contain_package('mongodb_mongos').with_name('mongo-foo').with_ensure('present').with_tag('mongodb_package') }
       end
 
       context 'service_manage => false' do

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -10,13 +10,13 @@ describe 'mongodb::repo' do
       end
 
       describe 'without parameters' do
-        it { is_expected.to raise_error(Puppet::Error, %r{unsupported}) }
+        it { is_expected.to raise_error(Puppet::Error, %r{required}) }
       end
 
       describe 'with version set' do
         let :params do
           {
-            version: '3.6.1'
+            version: '5.0'
           }
         end
 
@@ -26,14 +26,14 @@ describe 'mongodb::repo' do
 
           it do
             is_expected.to contain_yumrepo('mongodb').
-              with_baseurl('https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.6/$basearch/')
+              with_baseurl('https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/5.0/$basearch/')
           end
         when 'Suse'
           it { is_expected.to contain_class('mongodb::repo::zypper') }
 
           it do
             is_expected.to contain_zypprepo('mongodb').
-              with_baseurl('https://repo.mongodb.org/zypper/suse/$releasever_major/mongodb-org/3.6/$basearch/')
+              with_baseurl('https://repo.mongodb.org/zypper/suse/$releasever_major/mongodb-org/5.0/$basearch/')
           end
         when 'Debian'
           it { is_expected.to contain_class('mongodb::repo::apt') }
@@ -43,13 +43,13 @@ describe 'mongodb::repo' do
             it do
               is_expected.to contain_apt__source('mongodb').
                 with_location('https://repo.mongodb.org/apt/debian').
-                with_release("#{facts[:lsbdistcodename]}/mongodb-org/3.6")
+                with_release("#{facts[:lsbdistcodename]}/mongodb-org/5.0")
             end
           when 'Ubuntu'
             it do
               is_expected.to contain_apt__source('mongodb').
                 with_location('https://repo.mongodb.org/apt/ubuntu').
-                with_release("#{facts[:lsbdistcodename]}/mongodb-org/3.6")
+                with_release("#{facts[:lsbdistcodename]}/mongodb-org/5.0")
             end
           end
         else
@@ -60,7 +60,7 @@ describe 'mongodb::repo' do
       describe 'with proxy' do
         let :params do
           {
-            version: '3.6.1',
+            version: '5.0',
             proxy: 'http://proxy-server:8080',
             proxy_username: 'proxyuser1',
             proxy_password: 'proxypassword1'

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -24,15 +24,7 @@ describe 'mongodb::server' do
       let(:facts) { facts }
 
       let(:config_file) do
-        if facts[:os]['family'] == 'Debian'
-          if facts[:os]['release']['major'] =~ %r{(10)}
-            '/etc/mongod.conf'
-          else
-            '/etc/mongodb.conf'
-          end
-        else
-          '/etc/mongod.conf'
-        end
+        '/etc/mongod.conf'
       end
 
       let(:log_path) do
@@ -45,14 +37,7 @@ describe 'mongodb::server' do
 
       describe 'with defaults' do
         it_behaves_like 'server classes'
-
-        if facts[:os]['family'] == 'RedHat' || facts[:os]['family'] == 'Suse'
-          it { is_expected.to contain_package('mongodb_server').with_ensure('present').with_name('mongodb-org-server').with_tag('mongodb_package') }
-        elsif facts[:os]['release']['major'] =~ %r{(10)}
-          it { is_expected.to contain_package('mongodb_server').with_ensure('4.4.29').with_name('mongodb-org-server').with_tag('mongodb_package') }
-        else
-          it { is_expected.to contain_package('mongodb_server').with_ensure('present').with_name('mongodb-server').with_tag('mongodb_package') }
-        end
+        it { is_expected.to contain_package('mongodb_server').with_ensure('present').with_name('mongodb-org-server').with_tag('mongodb_package') }
 
         it do
           is_expected.to contain_file(config_file).


### PR DESCRIPTION
#### Pull Request (PR) description
Switch to using mongodb provided repo by default.

New globals parameter 'repo_version' to separate repo version from package version.
This is needed to manage repo without locking to package version.

Require  mongodb repo version >= 4.4 
