### PR TITLE
Remove gha pidfile_workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,3 @@ jobs:
   puppet:
     name: Puppet
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
-    with:
-      pidfile_workaround: 'CentOS,Ubuntu'

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,5 +1,3 @@
 ---
 appveyor.yml:
   delete: true
-.github/workflows/ci.yml:
-  pidfile_workaround: CentOS,Ubuntu


### PR DESCRIPTION
#### Pull Request (PR) description
The latest releases of mongodb does not declare PIDfile in the service files.
