### PR TITLE
Debian 10 support should not be dropped yet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,7 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
+        "10",
         "11"
       ]
     },


### PR DESCRIPTION
#### Pull Request (PR) description
Debian 10 is not EOL yet.
This PR reverts #704 