### PR TITLE
Set default redhat dbpath to /var/lib/mongo

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -336,16 +336,14 @@ Default value: `'mongos'`
 Data type: `String[1]`
 
 The user used by Systemd for running the service.
-
-Default value: `'mongodb'`
+If not specified, the module will use the default for your OS distro.
 
 ##### <a name="-mongodb--mongos--service_group"></a>`service_group`
 
 Data type: `String[1]`
 
 The group used by Systemd for running the service
-
-Default value: `'mongodb'`
+If not specified, the module will use the default for your OS distro.
 
 ##### <a name="-mongodb--mongos--service_template"></a>`service_template`
 
@@ -898,16 +896,12 @@ Data type: `String[1]`
 This setting can be used to override the default MongoDB user and owner of the service and related files in the file system.
 If not specified, the module will use the default for your OS distro.
 
-Default value: `'mongod'`
-
 ##### <a name="-mongodb--server--group"></a>`group`
 
 Data type: `String[1]`
 
 This setting can be used to override the default MongoDB user group to be used for related files in the file system.
 If not specified, the module will use the default for your OS distro.
-
-Default value: `'mongod'`
 
 ##### <a name="-mongodb--server--config"></a>`config`
 
@@ -923,8 +917,6 @@ Data type: `Stdlib::Absolutepath`
 
 Set this value to designate a directory for the mongod instance to store it's data.
 If not specified, the module will use the default for your OS distro.
-
-Default value: `'/var/lib/mongodb'`
 
 ##### <a name="-mongodb--server--dbpath_fix"></a>`dbpath_fix`
 

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -1,5 +1,7 @@
 ---
 mongodb::server::user: 'mongodb'
 mongodb::server::group: 'mongodb'
+mongodb::server::dbpath: '/var/lib/mongodb'
+mongodb::server::journal: false
 mongodb::mongos::service_user: 'mongodb'
 mongodb::mongos::service_group: 'mongodb'

--- a/data/Linux-family.yaml
+++ b/data/Linux-family.yaml
@@ -2,6 +2,7 @@
 # Amazon uses os family Linux
 mongodb::server::user: 'mongod'
 mongodb::server::group: 'mongod'
+mongodb::server::dbpath: '/var/lib/mongodb'
 mongodb::server::journal: true
 mongodb::mongos::service_user: 'mongod'
 mongodb::mongos::service_group: 'mongod'

--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -1,6 +1,7 @@
 ---
 mongodb::server::user: 'mongod'
 mongodb::server::group: 'mongod'
+mongodb::server::dbpath: '/var/lib/mongo'
 mongodb::server::journal: true
 mongodb::mongos::service_user: 'mongod'
 mongodb::mongos::service_group: 'mongod'

--- a/data/Suse-family.yaml
+++ b/data/Suse-family.yaml
@@ -1,6 +1,7 @@
 ---
 mongodb::server::user: 'mongod'
 mongodb::server::group: 'mongod'
+mongodb::server::dbpath: '/var/lib/mongodb'
 mongodb::server::journal: true
 mongodb::mongos::service_user: 'mongod'
 mongodb::mongos::service_group: 'mongod'

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -36,9 +36,11 @@
 #
 # @param service_user
 #   The user used by Systemd for running the service.
+#   If not specified, the module will use the default for your OS distro.
 #
 # @param service_group
 #   The group used by Systemd for running the service
+#   If not specified, the module will use the default for your OS distro.
 #
 # @param service_template
 #   Path to the service template if the default doesn't match one needs.
@@ -85,6 +87,8 @@
 #   Specifies whether the service should be restarted on config changes.
 #
 class mongodb::mongos (
+  String[1] $service_user,
+  String[1] $service_group,
   Stdlib::Absolutepath $config                       = '/etc/mongos.conf',
   Optional[String[1]] $config_content                = undef,
   Optional[String[1]] $config_template               = undef,
@@ -93,8 +97,6 @@ class mongodb::mongos (
   Boolean $service_manage                            = true,
   Optional[String] $service_provider                 = undef,
   String[1] $service_name                            = 'mongos',
-  String[1] $service_user                            = 'mongodb',
-  String[1] $service_group                           = 'mongodb',
   String[1] $service_template                        = 'mongodb/mongos/mongos.service-dropin.epp',
   Boolean $service_enable                            = true,
   Stdlib::Ensure::Service $service_ensure            = 'running',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -319,11 +319,11 @@
 #   Store admin credentials in mongoshrc.js file. Uses with create_admin parameter
 #
 class mongodb::server (
+  String[1] $user,
+  String[1] $group,
+  Stdlib::Absolutepath $dbpath,
   String[1] $ensure                                                       = 'present',
-  String[1] $user                                                         = 'mongod',
-  String[1] $group                                                        = 'mongod',
   Stdlib::Absolutepath $config                                            = '/etc/mongod.conf',
-  Stdlib::Absolutepath $dbpath                                            = '/var/lib/mongodb',
   Boolean $dbpath_fix                                                     = false,
   Optional[Stdlib::Absolutepath] $pidfilepath                             = undef,
   String[4,4] $pidfilemode                                                = '0644',


### PR DESCRIPTION
#### Pull Request (PR) description
Aligns the default dbpath with rpm package content.

**_RedHat and derivative users with existing deployments relying on the module default should explicitly set dbpath to the old default before upgrading the module._**

#### This Pull Request (PR) fixes the following issues
Fixes #714
