### PR TITLE
Provider cleanup

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -865,12 +865,6 @@ The following parameters are available in the `mongodb::server` class:
 * [`config_content`](#-mongodb--server--config_content)
 * [`config_template`](#-mongodb--server--config_template)
 * [`config_data`](#-mongodb--server--config_data)
-* [`ssl`](#-mongodb--server--ssl)
-* [`ssl_key`](#-mongodb--server--ssl_key)
-* [`ssl_ca`](#-mongodb--server--ssl_ca)
-* [`ssl_weak_cert`](#-mongodb--server--ssl_weak_cert)
-* [`ssl_invalid_hostnames`](#-mongodb--server--ssl_invalid_hostnames)
-* [`ssl_mode`](#-mongodb--server--ssl_mode)
 * [`tls`](#-mongodb--server--tls)
 * [`tls_key`](#-mongodb--server--tls_key)
 * [`tls_ca`](#-mongodb--server--tls_ca)
@@ -1444,56 +1438,6 @@ Data type: `Optional[Hash]`
 A hash to allow for additional configuration options to be set in user-provided template.
 
 Default value: `undef`
-
-##### <a name="-mongodb--server--ssl"></a>`ssl`
-
-Data type: `Optional[Boolean]`
-
-Use SSL validation.
-Important: You need to have ssl_key set as well, and the file needs to pre-exist on node. If you wish to
-use certificate validation, ssl_ca must also be set.
-
-Default value: `undef`
-
-##### <a name="-mongodb--server--ssl_key"></a>`ssl_key`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-Defines the path of the file that contains the TLS/SSL certificate and key.
-
-Default value: `undef`
-
-##### <a name="-mongodb--server--ssl_ca"></a>`ssl_ca`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-Defines the path of the file that contains the certificate chain for verifying client certificates.
-
-Default value: `undef`
-
-##### <a name="-mongodb--server--ssl_weak_cert"></a>`ssl_weak_cert`
-
-Data type: `Boolean`
-
-Set to true to disable mandatory SSL client authentication.
-
-Default value: `false`
-
-##### <a name="-mongodb--server--ssl_invalid_hostnames"></a>`ssl_invalid_hostnames`
-
-Data type: `Boolean`
-
-Set to true to disable fqdn SSL cert check.
-
-Default value: `false`
-
-##### <a name="-mongodb--server--ssl_mode"></a>`ssl_mode`
-
-Data type: `Enum['requireSSL', 'preferSSL', 'allowSSL']`
-
-Ssl authorization mode.
-
-Default value: `'requireSSL'`
 
 ##### <a name="-mongodb--server--tls"></a>`tls`
 

--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -11,13 +11,6 @@ def get_options_from_hash_config(config)
   result = []
 
   result << "--port #{config['net.port']}" unless config['net.port'].nil?
-  # use --ssl and --host if:
-  # - sslMode is "requireSSL"
-  # - Parameter --sslPEMKeyFile is set
-  # - Parameter --sslCAFile is set
-  result << "--ssl --host #{Facter.value(:fqdn)}" if config['net.ssl.mode'] == 'requireSSL' || !config['net.ssl.PEMKeyFile'].nil? || !config['net.ssl.CAFile'].nil?
-  result << "--sslPEMKeyFile #{config['net.ssl.PEMKeyFile']}" unless config['net.ssl.PEMKeyFile'].nil?
-  result << "--sslCAFile #{config['net.ssl.CAFile']}" unless config['net.ssl.CAFile'].nil?
   # use --tls and --host if:
   # - tlsMode is "requireTLS"
   # - Parameter --tlsCertificateKeyFile is set

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -26,15 +26,15 @@ class Puppet::Provider::Mongodb < Puppet::Provider
   def self.mongo_conf
     config = YAML.load_file(mongod_conf_file) || {}
     {
-      'bindip' => config['net.bindIp'],
-      'port' => config['net.port'],
-      'ipv6' => config['net.ipv6'],
-      'tlsallowInvalidHostnames' => config['net.tls.allowInvalidHostnames'],
-      'tls' => config['net.tls.mode'],
-      'tlscert' => config['net.tls.certificateKeyFile'],
-      'tlsca' => config['net.tls.CAFile'],
-      'auth' => config['security.authorization'],
-      'clusterRole' => config['sharding.clusterRole'],
+      'bindip' => config['net.bindIp'] || config.fetch('net', {}).fetch('bindIp', nil),
+      'port' => config['net.port'] || config.fetch('net', {}).fetch('port', nil),
+      'ipv6' => config['net.ipv6'] || config.fetch('net', {}).fetch('ipv6', nil),
+      'tlsallowInvalidHostnames' => config['net.tls.allowInvalidHostnames'] || config.fetch('net', {}).fetch('tls', {}).fetch('allowInvalidHostnames', nil),
+      'tls' => config['net.tls.mode'] || config.fetch('net', {}).fetch('tls', {}).fetch('mode', nil),
+      'tlscert' => config['net.tls.certificateKeyFile'] || config.fetch('net', {}).fetch('tls', {}).fetch('certificateKeyFile', nil),
+      'tlsca' => config['net.tls.CAFile'] || config.fetch('net', {}).fetch('tls', {}).fetch('CAFile', nil),
+      'auth' => config['security.authorization'] || config.fetch('security', {}).fetch('authorization', nil),
+      'clusterRole' => config['sharding.clusterRole'] || config.fetch('sharding', {}).fetch('clusterRole', nil),
     }
   end
 

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -29,10 +29,6 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       'bindip' => config['net.bindIp'],
       'port' => config['net.port'],
       'ipv6' => config['net.ipv6'],
-      'sslallowInvalidHostnames' => config['net.ssl.allowInvalidHostnames'],
-      'ssl' => config['net.ssl.mode'],
-      'sslcert' => config['net.ssl.PEMKeyFile'],
-      'sslca' => config['net.ssl.CAFile'],
       'tlsallowInvalidHostnames' => config['net.tls.allowInvalidHostnames'],
       'tls' => config['net.tls.mode'],
       'tlscert' => config['net.tls.certificateKeyFile'],
@@ -47,21 +43,10 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     config['ipv6']
   end
 
-  def self.ssl_is_enabled(config = nil)
-    config ||= mongo_conf
-    ssl_mode = config.fetch('ssl')
-    !ssl_mode.nil? && ssl_mode != 'disabled'
-  end
-
   def self.tls_is_enabled(config = nil)
     config ||= mongo_conf
     tls_mode = config.fetch('tls')
     !tls_mode.nil? && tls_mode != 'disabled'
-  end
-
-  def self.ssl_invalid_hostnames(config = nil)
-    config ||= mongo_conf
-    config['sslallowInvalidHostnames']
   end
 
   def self.tls_invalid_hostnames(config = nil)
@@ -76,16 +61,6 @@ class Puppet::Provider::Mongodb < Puppet::Provider
 
     args = [db, '--quiet', '--host', host]
     args.push('--ipv6') if ipv6_is_enabled(config)
-
-    if ssl_is_enabled(config)
-      args.push('--ssl')
-      args += ['--sslPEMKeyFile', config['sslcert']]
-
-      ssl_ca = config['sslca']
-      args += ['--sslCAFile', ssl_ca] unless ssl_ca.nil?
-
-      args.push('--sslAllowInvalidHostnames') if ssl_invalid_hostnames(config)
-    end
 
     if tls_is_enabled(config)
       args.push('--tls')

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -243,26 +243,6 @@
 # @param config_data
 #   A hash to allow for additional configuration options to be set in user-provided template.
 #
-# @param ssl
-#   Use SSL validation.
-#   Important: You need to have ssl_key set as well, and the file needs to pre-exist on node. If you wish to
-#   use certificate validation, ssl_ca must also be set.
-#
-# @param ssl_key
-#   Defines the path of the file that contains the TLS/SSL certificate and key.
-#
-# @param ssl_ca
-#   Defines the path of the file that contains the certificate chain for verifying client certificates.
-#
-# @param ssl_weak_cert
-#   Set to true to disable mandatory SSL client authentication.
-#
-# @param ssl_invalid_hostnames
-#   Set to true to disable fqdn SSL cert check.
-#
-# @param ssl_mode
-#   Ssl authorization mode.
-#
 # @param tls
 #   Ensure tls is enabled.
 #
@@ -381,12 +361,6 @@ class mongodb::server (
   $config_content                                                         = undef,
   Optional[String] $config_template                                       = undef,
   Optional[Hash] $config_data                                             = undef,
-  Optional[Boolean] $ssl                                                  = undef,
-  Optional[Stdlib::Absolutepath] $ssl_key                                 = undef,
-  Optional[Stdlib::Absolutepath] $ssl_ca                                  = undef,
-  Boolean $ssl_weak_cert                                                  = false,
-  Boolean $ssl_invalid_hostnames                                          = false,
-  Enum['requireSSL', 'preferSSL', 'allowSSL'] $ssl_mode                   = 'requireSSL',
   Boolean $tls                                                            = false,
   Optional[Stdlib::Absolutepath] $tls_key                                 = undef,
   Optional[Stdlib::Absolutepath] $tls_ca                                  = undef,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -62,12 +62,6 @@ class mongodb::server::config {
   $maxconns         = $mongodb::server::maxconns
   $set_parameter    = $mongodb::server::set_parameter
   $syslog           = $mongodb::server::syslog
-  $ssl              = $mongodb::server::ssl
-  $ssl_key          = $mongodb::server::ssl_key
-  $ssl_ca           = $mongodb::server::ssl_ca
-  $ssl_weak_cert    = $mongodb::server::ssl_weak_cert
-  $ssl_invalid_hostnames = $mongodb::server::ssl_invalid_hostnames
-  $ssl_mode         = $mongodb::server::ssl_mode
   $tls              = $mongodb::server::tls
   $tls_key          = $mongodb::server::tls_key
   $tls_ca           = $mongodb::server::tls_ca
@@ -80,8 +74,6 @@ class mongodb::server::config {
     owner => $user,
     group => $group,
   }
-
-  if ($ssl and $tls) { fail('You cannot use ssl and tls options together') }
 
   if ($ensure == 'present' or $ensure == true) {
     if $keyfile and $key {

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -310,29 +310,6 @@ describe 'mongodb::server' do
         end
       end
 
-      describe 'with ssl' do
-        context 'enabled' do
-          let :params do
-            {
-              ssl: true,
-              ssl_mode: 'requireSSL'
-            }
-          end
-
-          it { is_expected.to contain_file(config_file).with_content(%r{^net\.ssl\.mode: requireSSL$}) }
-        end
-
-        context 'disabled' do
-          let :params do
-            {
-              ssl: false
-            }
-          end
-
-          it { is_expected.not_to contain_file(config_file).with_content(%r{net\.ssl\.mode}) }
-        end
-      end
-
       describe 'with tls' do
         context 'enabled' do
           let :params do

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -108,19 +108,6 @@ net.maxIncomingConnections: <%= @maxconns %>
 <% if ! @nohttpinterface.nil? -%>
 net.http.enabled: <%= ! @nohttpinterface %>
 <% end -%>
-<% if @ssl -%>
-net.ssl.mode: <%= @ssl_mode %>
-net.ssl.PEMKeyFile: <%= @ssl_key %>
-<% if @ssl_ca -%>
-net.ssl.CAFile: <%= @ssl_ca %>
-<% end -%>
-<% if @ssl_weak_cert -%>
-net.ssl.weakCertificateValidation: <%= @ssl_weak_cert %>
-<% end -%>
-<% if @ssl_invalid_hostnames -%>
-net.ssl.allowInvalidHostnames: <%= @ssl_invalid_hostnames %>
-<% end -%>
-<% end -%>
 <% if @tls -%>
 net.tls.mode: <%= @tls_mode %>
 net.tls.certificateKeyFile: <%= @tls_key %>


### PR DESCRIPTION
This PR cleans up the provider.

A detailed list of changes:
- Remove deprecated SSL options (use TLS instead)
- Support pure yaml config in provider
- Refactor the replicaset provider to improve maintainability