### PR TITLE
Prefer connecting over localhost when possible

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -72,6 +72,8 @@ class Puppet::Provider::Mongodb < Puppet::Provider
   def self.mongosh_cmd(db, host, cmd)
     config = mongo_conf
 
+    host = conn_string if host.nil? || host.split(':')[0] == Facter.value(:fqdn) || host == '127.0.0.1'
+
     args = [db, '--quiet', '--host', host]
     args.push('--ipv6') if ipv6_is_enabled(config)
 
@@ -157,11 +159,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
 
     out = nil
     begin
-      out = if host
-              mongosh_cmd(db, host, cmd)
-            else
-              mongosh_cmd(db, conn_string, cmd)
-            end
+      out = mongosh_cmd(db, host, cmd)
     rescue StandardError => e
       retry_count -= 1
       if retry_count.positive?

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -72,12 +72,8 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
     mongo_command('db.isMaster()', host)
   end
 
-  def rs_initiate(conf, master)
-    if auth_enabled && auth_enabled != 'disabled'
-      mongo_command("rs.initiate(#{conf})", initialize_host)
-    else
-      mongo_command("rs.initiate(#{conf})", master)
-    end
+  def rs_initiate(conf)
+    mongo_command("rs.initiate(#{conf})", initialize_host)
   end
 
   def rs_status(host)
@@ -272,8 +268,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
       }.to_json
 
       Puppet.debug "Starting replset config is #{replset_conf.to_json}"
-      # Set replset members with the first host as the master
-      output = rs_initiate(replset_conf, alive_hosts[0]['host'])
+      output = rs_initiate(replset_conf)
       raise Puppet::Error, "rs.initiate() failed for replicaset #{name}: #{output['errmsg']}" if output['ok'].zero?
 
       # Check that the replicaset has finished initialization

--- a/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
@@ -43,7 +43,7 @@ describe Puppet::Type.type(:mongodb_replset).provider(:mongo) do
       allow(provider.class).to receive(:replset_properties)
       allow(provider).to receive(:get_hosts_status).and_return([valid_members, []])
       allow(provider).to receive(:master_host).and_return(false)
-      allow(provider).to receive(:rs_initiate).with('{"_id":"rs_test","members":[{"host":"mongo1:27017","_id":0},{"host":"mongo2:27017","_id":1},{"host":"mongo3:27017","_id":2}],"settings":{}}', 'mongo1:27017').and_return('info' => 'Config now saved locally.  Should come online in about a minute.', 'ok' => 1)
+      allow(provider).to receive(:rs_initiate).with('{"_id":"rs_test","members":[{"host":"mongo1:27017","_id":0},{"host":"mongo2:27017","_id":1},{"host":"mongo3:27017","_id":2}],"settings":{}}').and_return('info' => 'Config now saved locally.  Should come online in about a minute.', 'ok' => 1)
       allow(provider).to receive(:db_ismaster).and_return('{"ismaster" : true}')
       provider.create
       provider.flush


### PR DESCRIPTION
Setting up a replicaset without authentication failed as the mongosh command still requires authentication for some commands when auth is disabled and connecting from an external source.