### PR TITLE
Use ensure pruned to remove packages in acceptance tests

### DIFF
--- a/spec/acceptance/mongos_spec.rb
+++ b/spec/acceptance/mongos_spec.rb
@@ -65,12 +65,12 @@ describe 'mongodb::mongos class', if: supported_version?(default[:platform], rep
         }
         -> class { 'mongodb::server':
           ensure         => absent,
-          package_ensure => absent,
+          package_ensure => purged,
           service_ensure => stopped,
           service_enable => false
         }
         -> class { 'mongodb::client':
-          ensure => absent,
+          ensure => purged,
         }
       EOS
       apply_manifest(pp, catch_failures: true)

--- a/spec/acceptance/replset_spec.rb
+++ b/spec/acceptance/replset_spec.rb
@@ -17,12 +17,12 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
         }
         -> class { 'mongodb::server':
           ensure         => absent,
-          package_ensure => absent,
+          package_ensure => purged,
           service_ensure => stopped
         }
         if $::osfamily == 'RedHat' {
           class { 'mongodb::client':
-            ensure => absent
+            ensure => purged
           }
         }
       EOS
@@ -91,12 +91,12 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
         }
         -> class { 'mongodb::server':
           ensure => absent,
-          package_ensure => absent,
+          package_ensure => purged,
           service_ensure => stopped
         }
         if $::osfamily == 'RedHat' {
           class { 'mongodb::client':
-            ensure => absent
+            ensure => purged
           }
         }
       EOS

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -159,11 +159,11 @@ describe 'mongodb::server class', if: supported_version?(default[:platform], rep
       pp = <<-EOS
         class { 'mongodb::server':
             ensure => absent,
-            package_ensure => absent,
+            package_ensure => purged,
             service_ensure => stopped,
             service_enable => false
           }
-        -> class { 'mongodb::client': ensure => absent, }
+        -> class { 'mongodb::client': ensure => purged, }
       EOS
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)


### PR DESCRIPTION
#### Pull Request (PR) description
When trying to figure out mongod.conf package defaults I used server_spec.rb as a base to explore because it leaves the machine in a state where the repo is set up and client/server is not installed.
But on debian/ubuntu when I ran `apt install mongodb-org-server` it didn't install /etc/mongod.conf ...

Figured the reason to be this combination:
```
class { 'mongodb::server':
  ensure => absent,
  package_ensure => absent,
}
```
In this case apt remove is used on mongodb-org-server which don't remove documentation.
As /etc/mongod.conf is treated as docs by apt the file was not removed by apt.
But the mongodb::server::config class removes the apt managed /etc/mongod.conf.
When reinstalling apt still think /etc/mongod.conf is there and won't install it....
