### PR TITLE
Remove nojournal parameter; Cleanup journal management

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -827,7 +827,6 @@ The following parameters are available in the `mongodb::server` class:
 * [`fork`](#-mongodb--server--fork)
 * [`port`](#-mongodb--server--port)
 * [`journal`](#-mongodb--server--journal)
-* [`nojournal`](#-mongodb--server--nojournal)
 * [`smallfiles`](#-mongodb--server--smallfiles)
 * [`cpu`](#-mongodb--server--cpu)
 * [`auth`](#-mongodb--server--auth)
@@ -1103,16 +1102,9 @@ Default value: `undef`
 
 Data type: `Optional[Boolean]`
 
-Set to true to enable operation journaling to ensure write durability and data consistency.
-
-Default value: `undef`
-
-##### <a name="-mongodb--server--nojournal"></a>`nojournal`
-
-Data type: `Optional[Boolean]`
-
-Set nojournal = true to disable durability journaling. By default, mongod enables journaling in 64-bit versions after v2.0.
-Note: You must use journal to enable journaling on 32-bit systems.
+Enable or disable the durability journal to ensure data files remain valid and recoverable.
+Available in MongoDB < 7.0
+Default: true on 64-bit systems, false on 32-bit systems
 
 Default value: `undef`
 

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -2,6 +2,5 @@
 mongodb::server::user: 'mongodb'
 mongodb::server::group: 'mongodb'
 mongodb::server::dbpath: '/var/lib/mongodb'
-mongodb::server::journal: false
 mongodb::mongos::service_user: 'mongodb'
 mongodb::mongos::service_group: 'mongodb'

--- a/data/Linux-family.yaml
+++ b/data/Linux-family.yaml
@@ -3,6 +3,5 @@
 mongodb::server::user: 'mongod'
 mongodb::server::group: 'mongod'
 mongodb::server::dbpath: '/var/lib/mongodb'
-mongodb::server::journal: true
 mongodb::mongos::service_user: 'mongod'
 mongodb::mongos::service_group: 'mongod'

--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -2,6 +2,5 @@
 mongodb::server::user: 'mongod'
 mongodb::server::group: 'mongod'
 mongodb::server::dbpath: '/var/lib/mongo'
-mongodb::server::journal: true
 mongodb::mongos::service_user: 'mongod'
 mongodb::mongos::service_group: 'mongod'

--- a/data/Suse-family.yaml
+++ b/data/Suse-family.yaml
@@ -2,6 +2,5 @@
 mongodb::server::user: 'mongod'
 mongodb::server::group: 'mongod'
 mongodb::server::dbpath: '/var/lib/mongodb'
-mongodb::server::journal: true
 mongodb::mongos::service_user: 'mongod'
 mongodb::mongos::service_group: 'mongod'

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -21,7 +21,6 @@ class mongodb::server::config {
   $fork             = $mongodb::server::fork
   $port             = $mongodb::server::port
   $journal          = $mongodb::server::journal
-  $nojournal        = $mongodb::server::nojournal
   $smallfiles       = $mongodb::server::smallfiles
   $cpu              = $mongodb::server::cpu
   $auth             = $mongodb::server::auth

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -44,10 +44,8 @@ processManagement:
 
 #Storage
 storage.dbPath: <%= @dbpath %>
-<% if @nojournal -%>
-storage.journal.enabled: false
-<% elsif @journal -%>
-storage.journal.enabled: true
+<% if @journal != nil -%>
+storage.journal.enabled: <%= @journal %>
 <% end -%>
 <% if @noprealloc -%>
 storage.preallocDataFiles: <%= !@noprealloc %>


### PR DESCRIPTION
#### Pull Request (PR) description
Removing duplicate param to manage `storage.journal.enabled`
Usage of `nojournal => true` must be changed to `journal => false`

In addition `storage.journal.enabled` is removed in mongodb 7
