### PR TITLE
Define correct repo on absence tests

### DIFF
--- a/spec/acceptance/mongos_spec.rb
+++ b/spec/acceptance/mongos_spec.rb
@@ -60,7 +60,10 @@ describe 'mongodb::mongos class', if: supported_version?(default[:platform], rep
   describe 'uninstalling' do
     it 'uninstalls mongodb' do
       pp = <<-EOS
-        class { 'mongodb::mongos':
+        class { 'mongodb::globals':
+          #{repo_ver_param}
+        }
+        -> class { 'mongodb::mongos':
           package_ensure => 'purged',
         }
         -> class { 'mongodb::server':

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -157,7 +157,10 @@ describe 'mongodb::server class', if: supported_version?(default[:platform], rep
   describe 'uninstallation' do
     it 'uninstalls mongodb' do
       pp = <<-EOS
-        class { 'mongodb::server':
+        class { 'mongodb::globals':
+          #{repo_ver_param}
+        }
+        -> class { 'mongodb::server':
             ensure => absent,
             package_ensure => purged,
             service_ensure => stopped,


### PR DESCRIPTION
Without this, the cleanup switches repos.  I don't think this is really affecting things, but it makes the test output very confusing.

Notice: /Stage[main]/Mongodb::Repo::Yum/Yumrepo[mongodb]/baseurl: baseurl changed 'https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/5.0/$basearch/' to 'https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/6.0/$basearch/'