### PR TITLE
Fix replicaset provider when auth is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,69 @@ mongodb::db { 'testdb':
 Parameter 'password_hash' is hex encoded md5 hash of "user1:mongo:pass1".
 Unsafe plain text password could be used with 'password' parameter instead of 'password_hash'.
 
+### Replica sets
+
+When deciding to use replica setups (recommended for production environments)
+there are a few things to keep in mind when using this module.
+
+When setting up replicasets, prefer fully qualified domain names.
+
+#### Basic usage with authentication
+
+```puppet
+class { 'mongodb::server':
+  auth                 => true,
+  create_admin         => true,
+  admin_username       => 'admin',
+  admin_password       => $admin_password,
+  admin_auth_mechanism => 'scram_sha_256',
+  store_creds          => true,
+  handle_creds         => true,
+  replset              => 'rs0',
+  replset_members      => [
+    'mongo1.example.com:27017',
+    'mongo2.example.com:27017',
+    'mongo3.example.com:27017'
+   ],
+}
+class { 'mongodb::client' }
+```
+
+#### Basic usage without authentication
+
+First set up a basic installation on all nodes:
+
+```puppet
+class { 'mongodb::server':
+  auth    => false,
+  replset => 'rs0',
+}
+class { 'mongodb::client' }
+```
+
+Modify manifest and run on a single node:
+
+```puppet
+class { 'mongodb::server':
+  auth            => false,
+  replset         => 'rs0',
+  replset_members => [
+    'mongo1.example.com:27017',
+    'mongo2.example.com:27017',
+    'mongo3.example.com:27017'
+   ],
+}
+class { 'mongodb::client' }
+```
+
+This initiates the replicaset on the first node.
+From now on, this can be run on any node without changes to the node.
+
+#### Limitations
+
+This module may **not** be able to update a replica set once it is created when
+authentication is disabled.
+
 ### Sharding
 
 If one plans to configure sharding for a Mongo deployment, the module offer

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -127,30 +127,21 @@ class Puppet::Provider::Mongodb < Puppet::Provider
   end
 
   # Mongo Command Wrapper
-  def self.mongo_eval(cmd, db = 'admin', retries = 10, host = nil)
-    retry_count = retries
-    retry_sleep = 3
+  def self.mongo_eval(cmd, db = 'admin', host = nil)
     cmd = mongoshrc_file + cmd if mongoshrc_file
 
     out = nil
     begin
       out = mongosh_cmd(db, host, cmd)
     rescue StandardError => e
-      retry_count -= 1
-      if retry_count.positive?
-        Puppet.debug "Request failed: '#{e.message}' Retry: '#{retries - retry_count}'"
-        sleep retry_sleep
-        retry
-      end
+      raise Puppet::ExecutionFailure, "Could not evaluate MongoDB shell command: #{cmd}, with: #{e.message}"
     end
-
-    raise Puppet::ExecutionFailure, "Could not evaluate MongoDB shell command: #{cmd}, with: #{e.message}" unless out
 
     Puppet::Util::MongodbOutput.sanitize(out)
   end
 
-  def mongo_eval(cmd, db = 'admin', retries = 10, host = nil)
-    self.class.mongo_eval(cmd, db, retries, host)
+  def mongo_eval(cmd, db = 'admin', host = nil)
+    self.class.mongo_eval(cmd, db, host)
   end
 
   # Mongo Version checker

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -195,8 +195,8 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
       rescue Puppet::ExecutionFailure => e
         raise Puppet::Error, "Can't configure replicaset #{name}, host #{host} is not supposed to be part of a replicaset." if e.message =~ %r{not running with --replSet}
 
-        if auth_enabled && (e.message.include?('unauthorized') || e.message.include?('not authorized') || e.message.include?('requires authentication'))
-          Puppet.warning "Host #{host} is available, but you are unauthorized because of authentication is enabled: #{auth_enabled}"
+        if e.message.include?('unauthorized') || e.message.include?('not authorized') || e.message.include?('requires authentication')
+          Puppet.warning "Host #{host} is available, but you are unauthorized. Authentication enabled: #{auth_enabled}"
           alive.push(member)
         elsif e.message.include?('no replset config has been received')
           Puppet.debug 'Mongo v4 rs.status() RS not initialized output'

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -409,13 +409,13 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
     raise Puppet::Error, "rs.reconfig() failed to update settings in replicaset #{name}: #{output['errmsg']}" if output['ok'].zero?
   end
 
-  def mongo_command(command, host, retries = 4)
-    self.class.mongo_command(command, host, retries)
+  def mongo_command(command, host)
+    self.class.mongo_command(command, host)
   end
 
-  def self.mongo_command(command, host = nil, retries = 4)
+  def self.mongo_command(command, host = nil)
     begin
-      output = mongo_eval("EJSON.stringify(#{command})", 'admin', retries, host)
+      output = mongo_eval("EJSON.stringify(#{command})", 'admin', host)
     rescue Puppet::ExecutionFailure => e
       Puppet.debug "Got an exception: #{e}"
       raise

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -110,7 +110,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
       update_members(alive_hosts)
       update_settings if !@property_flush[:settings].nil? && !@property_flush[:settings].empty?
     end
-    @property_hash = self.class.replset_properties
+    @property_hash = resource.to_hash
   end
 
   private

--- a/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
@@ -48,7 +48,6 @@ describe Puppet::Type.type(:mongodb_replset).provider(:mongo) do
       provider.create
       provider.flush
 
-      expect(provider.class).to have_received(:replset_properties)
       expect(provider).to have_received(:get_hosts_status)
       expect(provider).to have_received(:master_host)
       expect(provider).to have_received(:rs_initiate)


### PR DESCRIPTION
When authentication is disabled, MongoDB still tells you are unauthorised.

Fixes #731