### PR TITLE
Remove the retry mechanism from the provider

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -127,30 +127,21 @@ class Puppet::Provider::Mongodb < Puppet::Provider
   end
 
   # Mongo Command Wrapper
-  def self.mongo_eval(cmd, db = 'admin', retries = 10, host = nil)
-    retry_count = retries
-    retry_sleep = 3
+  def self.mongo_eval(cmd, db = 'admin', host = nil)
     cmd = mongoshrc_file + cmd if mongoshrc_file
 
     out = nil
     begin
       out = mongosh_cmd(db, host, cmd)
     rescue StandardError => e
-      retry_count -= 1
-      if retry_count.positive?
-        Puppet.debug "Request failed: '#{e.message}' Retry: '#{retries - retry_count}'"
-        sleep retry_sleep
-        retry
-      end
+      raise Puppet::ExecutionFailure, "Could not evaluate MongoDB shell command: #{cmd}, with: #{e.message}"
     end
-
-    raise Puppet::ExecutionFailure, "Could not evaluate MongoDB shell command: #{cmd}, with: #{e.message}" unless out
 
     Puppet::Util::MongodbOutput.sanitize(out)
   end
 
-  def mongo_eval(cmd, db = 'admin', retries = 10, host = nil)
-    self.class.mongo_eval(cmd, db, retries, host)
+  def mongo_eval(cmd, db = 'admin', host = nil)
+    self.class.mongo_eval(cmd, db, host)
   end
 
   # Mongo Version checker

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -384,13 +384,13 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
     raise Puppet::Error, "rs.reconfig() failed to update settings in replicaset #{name}: #{output['errmsg']}" if output['ok'].zero?
   end
 
-  def mongo_command(command, host, retries = 4)
-    self.class.mongo_command(command, host, retries)
+  def mongo_command(command, host)
+    self.class.mongo_command(command, host)
   end
 
-  def self.mongo_command(command, host = nil, retries = 4)
+  def self.mongo_command(command, host = nil)
     begin
-      output = mongo_eval("EJSON.stringify(#{command})", 'admin', retries, host)
+      output = mongo_eval("EJSON.stringify(#{command})", 'admin', host)
     rescue Puppet::ExecutionFailure => e
       Puppet.debug "Got an exception: #{e}"
       raise


### PR DESCRIPTION
Since the switch to `mongosh` this significantly slows down operations, as any error now results in an exception causing the retry, even when no retry is needed. This used to be there to catch connection errors.