### PR TITLE
feat: Add tls_invalid_certificates argument

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -869,6 +869,7 @@ The following parameters are available in the `mongodb::server` class:
 * [`tls_ca`](#-mongodb--server--tls_ca)
 * [`tls_conn_without_cert`](#-mongodb--server--tls_conn_without_cert)
 * [`tls_invalid_hostnames`](#-mongodb--server--tls_invalid_hostnames)
+* [`tls_invalid_certificates`](#-mongodb--server--tls_invalid_certificates)
 * [`tls_mode`](#-mongodb--server--tls_mode)
 * [`admin_password_hash`](#-mongodb--server--admin_password_hash)
 * [`restart`](#-mongodb--server--restart)
@@ -1473,6 +1474,15 @@ Default value: `undef`
 Data type: `Optional[Boolean]`
 
 Set to true to disable the validation of the hostnames in TLS certificates.
+
+Default value: `undef`
+
+##### <a name="-mongodb--server--tls_invalid_certificates"></a>`tls_invalid_certificates`
+
+Data type: `Optional[Boolean]`
+
+Enable or disable the validation checks for TLS certificates on other servers in the cluster and allows the use of
+invalid certificates to connect.
 
 Default value: `undef`
 

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -54,6 +54,11 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     config['tlsallowInvalidHostnames']
   end
 
+  def self.tls_invalid_certificates(config = nil)
+    config ||= mongo_conf
+    config['tlsallowInvalidCertificates']
+  end
+
   def self.mongosh_cmd(db, host, cmd)
     config = mongo_conf
 
@@ -70,6 +75,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       args += ['--tlsCAFile', tls_ca] unless tls_ca.nil?
 
       args.push('--tlsAllowInvalidHostnames') if tls_invalid_hostnames(config)
+      args.push('--tlsAllowInvalidCertificates') if tls_invalid_certificates(config)
     end
 
     args += ['--eval', cmd]

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -261,6 +261,10 @@
 # @param tls_invalid_hostnames
 #   Set to true to disable the validation of the hostnames in TLS certificates.
 #
+# @param tls_invalid_certificates
+#   Enable or disable the validation checks for TLS certificates on other servers in the cluster and allows the use of
+#   invalid certificates to connect.
+#
 # @param tls_mode
 #   Defines if TLS is used for all network connections. Allowed values are 'requireTLS', 'preferTLS' or 'allowTLS'.
 #
@@ -368,6 +372,7 @@ class mongodb::server (
   Optional[Stdlib::Absolutepath] $tls_ca                                  = undef,
   Optional[Boolean] $tls_conn_without_cert                                = undef,
   Optional[Boolean] $tls_invalid_hostnames                                = undef,
+  Optional[Boolean] $tls_invalid_certificates                             = undef,
   Enum['requireTLS', 'preferTLS', 'allowTLS'] $tls_mode                   = 'requireTLS',
   Boolean $restart                                                        = true,
   Optional[String] $storage_engine                                        = undef,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -66,6 +66,7 @@ class mongodb::server::config {
   $tls_ca           = $mongodb::server::tls_ca
   $tls_conn_without_cert = $mongodb::server::tls_conn_without_cert
   $tls_invalid_hostnames = $mongodb::server::tls_invalid_hostnames
+  $tls_invalid_certificates = $mongodb::server::tls_invalid_certificates
   $tls_mode         = $mongodb::server::tls_mode
   $storage_engine   = $mongodb::server::storage_engine
 

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -136,6 +136,9 @@
   <%- if !@tls_invalid_hostnames.nil? -%>
     <%- config_hash['net']['tls']['allowInvalidHostnames'] = @tls_invalid_hostnames -%>
   <%- end -%>
+  <%- if !@tls_invalid_certificates.nil? -%>
+    <%- config_hash['net']['tls']['allowInvalidCertificates'] = @tls_invalid_certificates -%>
+  <%- end -%>
 <%- end -%>
 <%- if @replset || @oplog_size -%>
   <%- if !config_hash['replication'] -%>


### PR DESCRIPTION
Hello,

Since MongoDB 7.0.6, when CAFile nor clusterCAFile is provided, the server refuses to start.

https://jira.mongodb.org/browse/SERVER-72839

Servers having self-signed certificates must define:
* `tlsUseSystemCA` (via `set_parameters`)
* `net.tls.allowInvalidCertificates`

https://www.mongodb.com/docs/manual/reference/configuration-options/#mongodb-setting-net.tls.allowInvalidCertificates

This commit enables `net.tls.allowInvalidCertificates` via `tls_invalid_certificates`.