### PR TITLE
Fix replset and sharding integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,5 @@ jobs:
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
     with:
       pidfile_workaround: 'false'
+      beaker_hosts: 'host1:shard.ma;host2:slave,router.a'
       beaker_facter: 'mongodb_repo_version:MongoDB:4.4,5.0,6.0,7.0'

--- a/.sync.yml
+++ b/.sync.yml
@@ -2,4 +2,6 @@
 appveyor.yml:
   delete: true
 .github/workflows/ci.yml:
-  beaker_facter: 'mongodb_repo_version:MongoDB:4.4,5.0,6.0,7.0'
+  with:
+    beaker_hosts: 'host1:shard.ma;host2:slave,router.a'
+    beaker_facter: 'mongodb_repo_version:MongoDB:4.4,5.0,6.0,7.0'

--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -9,12 +9,16 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, parent: Puppet::Provider:
   def self.instances
     require 'json'
 
-    pre_cmd = 'db.getMongo().setReadPref("primaryPreferred")'
-    dbs = JSON.parse mongo_eval("#{pre_cmd};EJSON.stringify(db.getMongo().getDBs())")
+    if db_ismaster
+      dbs = JSON.parse mongo_eval('EJSON.stringify(db.getMongo().getDBs())')
 
-    dbs['databases'].map do |db|
-      new(name: db['name'],
-          ensure: :present)
+      dbs['databases'].map do |db|
+        new(name: db['name'],
+            ensure: :present)
+      end
+    else
+      Puppet.warning 'Database info is available only from master host'
+      []
     end
   end
 

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -284,14 +284,14 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, parent: Puppet::Provider::Mo
     retry_sleep = 3
 
     retry_limit.times do |n|
-      if db_ismaster(alive_hosts[0]['host'])['ismaster']
-        Puppet.debug 'Replica set initialization has successfully ended'
-        return true
-      else
-        Puppet.debug "Waiting for replica initialization. Retry: #{n}"
-        sleep retry_sleep
-        next
+      alive_hosts.each do |alive_host|
+        if db_ismaster(alive_host['host'])['ismaster']
+          Puppet.debug 'Replica set initialization has successfully ended'
+          return true
+        end
       end
+      Puppet.debug "Waiting for replica initialization. Retry: #{n}"
+      sleep retry_sleep
     end
     raise Puppet::Error, "rs.initiate() failed for replicaset #{name}"
   end

--- a/lib/puppet/provider/mongodb_shard/mongo.rb
+++ b/lib/puppet/provider/mongodb_shard/mongo.rb
@@ -102,7 +102,7 @@ Puppet::Type.type(:mongodb_shard).provide(:mongo, parent: Puppet::Provider::Mong
 
   def self.shard_properties(shard)
     properties = {}
-    output = mongo_command('sh.status()')
+    output = mongo_command('sh.status()')['value']
     output['shards'].each do |s|
       next unless s['_id'] == shard
 
@@ -118,7 +118,7 @@ Puppet::Type.type(:mongodb_shard).provide(:mongo, parent: Puppet::Provider::Mong
   end
 
   def self.shards_properties
-    output = mongo_command('sh.status()')
+    output = mongo_command('sh.status()')['value']
     properties = if output['shards'].empty?
                    []
                  else
@@ -163,64 +163,6 @@ Puppet::Type.type(:mongodb_shard).provide(:mongo, parent: Puppet::Provider::Mong
       retry
     end
 
-    # NOTE: (spredzy) : sh.status()
-    # does not return a json stream
-    # we jsonify it so it is easier
-    # to parse and deal with it
-    if command == 'sh.status()'
-      myarr = output.split("\n")
-      myarr.shift
-      myarr.pop
-      myarr.pop
-      final_stream = []
-      prev_line = nil
-      in_shard_list = 0
-      in_chunk = 0
-      myarr.each do |line|
-        line.gsub!(%r{sharding version:}, '{ "sharding version":')
-        line.gsub!(%r{shards:}, ',"shards":[')
-        line.gsub!(%r{databases:}, '], "databases":[')
-        line.gsub!(%r{"clusterId" : ObjectId\("(.*)"\)}, '"clusterId" : "ObjectId(\'\1\')"')
-        line.gsub!(%r{\{  "_id" :}, ',{  "_id" :') if %r{_id} =~ prev_line
-        # Modification for shard
-        line = '' if line =~ %r{on :.*Timestamp}
-        if line =~ %r{_id} && in_shard_list == 1
-          in_shard_list = 0
-          last_line = final_stream.pop.strip
-          proper_line = "#{last_line}]},"
-          final_stream << proper_line
-        end
-        if line =~ %r{shard key} && in_shard_list == 1
-          shard_name = final_stream.pop.strip
-          proper_line = ",{\"#{shard_name}\":"
-          final_stream << proper_line
-        end
-        if line =~ %r{shard key} && in_shard_list.zero?
-          in_shard_list = 1
-          shard_name = final_stream.pop.strip
-          id_line = "#{final_stream.pop[0..-2]}, \"shards\": "
-          proper_line = "[{\"#{shard_name}\":"
-          final_stream << id_line
-          final_stream << proper_line
-        end
-        if in_chunk == 1
-          in_chunk = 0
-          line = "\"#{line.strip}\"}}"
-        end
-        in_chunk = 1 if line =~ %r{chunks} && in_chunk.zero?
-        line.gsub!(%r{shard key}, '{"shard key"')
-        line.gsub!(%r{chunks}, ',"chunks"')
-        final_stream << line unless line.empty?
-        prev_line = line
-      end
-      final_stream << ' ] }' if in_shard_list == 1
-      final_stream << ' ] }'
-      output = final_stream.join("\n")
-    end
-
-    # Hack to avoid non-json empty sets
-    output = '{}' if output == "null\n"
-    output.gsub!(%r{\s*}, '')
     JSON.parse(output)
   end
 end

--- a/spec/acceptance/replset_spec.rb
+++ b/spec/acceptance/replset_spec.rb
@@ -8,9 +8,6 @@ repo_ver_param = "repo_version => '#{repo_version}'" if repo_version
 if hosts.length > 1 && supported_version?(default[:platform], repo_version)
   describe 'mongodb_replset resource' do
     after :all do
-      # Have to drop the DB to disable replsets for further testing
-      on hosts, %{mongosh local --verbose --eval 'db.dropDatabase()'}
-
       pp = <<-EOS
         class { 'mongodb::globals':
           #{repo_ver_param}
@@ -20,10 +17,8 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
           package_ensure => purged,
           service_ensure => stopped
         }
-        if $::osfamily == 'RedHat' {
-          class { 'mongodb::client':
-            ensure => purged
-          }
+        -> class { 'mongodb::client':
+          ensure => purged
         }
       EOS
 
@@ -36,12 +31,10 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
           #{repo_ver_param}
         }
         -> class { 'mongodb::server':
-          bind_ip => '0.0.0.0',
+          bind_ip => ['0.0.0.0'],
           replset => 'test',
         }
-        if $::osfamily == 'RedHat' {
-          class { 'mongodb::client': }
-        }
+        -> class { 'mongodb::client': }
       EOS
 
       apply_manifest_on(hosts.reverse, pp, catch_failures: true)
@@ -59,11 +52,15 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
         expect(r.stdout).to match %r{#{hosts[0]}:27017}
         expect(r.stdout).to match %r{#{hosts[1]}:27017}
       end
+      sleep(30)
+      on(hosts_as('slave'), 'mongosh --quiet --eval "EJSON.stringify(rs.conf())"') do |r|
+        expect(r.stdout).to match %r{#{hosts[0]}:27017}
+        expect(r.stdout).to match %r{#{hosts[1]}:27017}
+      end
     end
 
     it 'inserts data on the master' do
-      sleep(30)
-      on hosts_as('master'), %{mongosh --verbose --eval 'db.test.save({name:"test1",value:"some value"})'}
+      on hosts_as('master'), %{mongosh --verbose --eval 'db.test.insertOne({name:"test1",value:"some value"})'}
     end
 
     it 'checks the data on the master' do
@@ -74,7 +71,73 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
 
     it 'checks the data on the slave' do
       sleep(10)
-      on hosts_as('slave'), %{mongosh --verbose --eval 'db.getMongo().setReadPref("primaryPreferred"); EJSON.stringify(db.test.findOne({name:"test1"}))'} do |r|
+      on hosts_as('slave'), %{mongosh --verbose --eval 'EJSON.stringify(db.test.findOne({name:"test1"}))'} do |r|
+        expect(r.stdout).to match %r{some value}
+      end
+    end
+  end
+
+  describe 'mongodb::server with replset_members' do
+    after :all do
+      pp = <<-EOS
+        class { 'mongodb::globals':
+          #{repo_ver_param}
+        }
+        -> class { 'mongodb::server':
+          ensure         => absent,
+          package_ensure => purged,
+          service_ensure => stopped
+        }
+        -> class { 'mongodb::client':
+          ensure => purged
+        }
+      EOS
+
+      apply_manifest_on(hosts.reverse, pp, catch_failures: true)
+    end
+
+    it 'configures mongo on both nodes' do
+      pp = <<-EOS
+        class { 'mongodb::globals':
+          #{repo_ver_param}
+        }
+        -> class { 'mongodb::server':
+          bind_ip => ['0.0.0.0'],
+          replset => 'test',
+          replset_members => [#{hosts.map { |x| "'#{x}:27017'" }.join(',')}],
+        }
+        -> class { 'mongodb::client': }
+      EOS
+
+      apply_manifest_on(hosts, pp, catch_failures: true)
+      apply_manifest_on(hosts, pp, catch_changes: true)
+    end
+
+    it 'sets up the replset with puppet' do
+      on(hosts_as('master'), 'mongosh --quiet --eval "EJSON.stringify(rs.conf())"') do |r|
+        expect(r.stdout).to match %r{#{hosts[0]}:27017}
+        expect(r.stdout).to match %r{#{hosts[1]}:27017}
+      end
+      sleep(30)
+      on(hosts_as('slave'), 'mongosh --quiet --eval "EJSON.stringify(rs.conf())"') do |r|
+        expect(r.stdout).to match %r{#{hosts[0]}:27017}
+        expect(r.stdout).to match %r{#{hosts[1]}:27017}
+      end
+    end
+
+    it 'inserts data on the master' do
+      on hosts_as('master'), %{mongosh --verbose --eval 'db.getMongo().setReadPref("primaryPreferred");db.test.insertOne({name:"test1",value:"some value"})'}
+    end
+
+    it 'checks the data on the master' do
+      on hosts_as('master'), %{mongosh --verbose --eval 'EJSON.stringify(db.test.findOne({name:"test1"}))'} do |r|
+        expect(r.stdout).to match %r{some value}
+      end
+    end
+
+    it 'checks the data on the slave' do
+      sleep(10)
+      on hosts_as('slave'), %{mongosh --verbose --eval 'EJSON.stringify(db.test.findOne({name:"test1"}))'} do |r|
         expect(r.stdout).to match %r{some value}
       end
     end
@@ -82,9 +145,6 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
 
   describe 'mongodb_replset resource with auth => true' do
     after :all do
-      # Have to drop the DB to disable replsets for further testing
-      on hosts, %{mongosh local --verbose --eval 'db.dropDatabase()'}
-
       pp = <<-EOS
         class { 'mongodb::globals':
           #{repo_ver_param}
@@ -94,28 +154,36 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
           package_ensure => purged,
           service_ensure => stopped
         }
-        if $::osfamily == 'RedHat' {
-          class { 'mongodb::client':
-            ensure => purged
-          }
+        -> class { 'mongodb::client':
+          ensure => purged
         }
       EOS
 
       apply_manifest_on(hosts.reverse, pp, catch_failures: true)
     end
 
+    let(:keyfile_path) do
+      os_family = fact('os.family')
+      if os_family == 'RedHat'
+        '/var/lib/mongo'
+      else
+        '/var/lib/mongodb'
+      end
+    end
+
     it 'configures mongo on both nodes' do
       pp = <<~EOS
         class { 'mongodb::globals':
           #{repo_ver_param}
-        } ->
-        class { 'mongodb::server':
+        }
+        -> class { 'mongodb::server':
           admin_username => 'admin',
           admin_password => 'password',
           auth           => true,
-          bind_ip        => '0.0.0.0',
+          store_creds    => true,
+          bind_ip        => ['0.0.0.0'],
           replset        => 'test',
-          keyfile        => '/var/lib/mongodb/mongodb-keyfile',
+          keyfile        => "#{keyfile_path}/mongodb-keyfile",
           key            => '+dxlTrury7xtD0FRqFf3YWGnKqWAtlyauuemxuYuyz9POPUuX1Uj3chGU8MFMHa7
         UxASqex7NLMALQXHL+Th4T3dyb6kMZD7KiMcJObO4M+JLiX9drcTiifsDEgGMi7G
         vYn3pWSm5TTDrHJw7RNWfMHw3sHk0muGQcO+0dWv3sDJ6SiU8yOKRtYcTEA15GbP
@@ -131,11 +199,9 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
         g+Bybk5qHv1b7M8Tv9/I/BRXcpLHeIkMICMY8sVPGmP8xzL1L3i0cws8p5h0zPBa
         YG/QX0BmltAni8owgymFuyJgvr/gaRX4WHbKFD+9nKpqJ3ocuVNuCDsxDqLsJEME
         nc1ohyB0lNt8lHf1U00mtgDSV3fwo5LkwhRi6d+bDBTL/C6MZETMLdyCqDlTdUWG
-        YXIsJ0gYcu9XG3mx10LbdPJvxSMg'
+        YXIsJ0gYcu9XG3mx10LbdPJvxSMg',
         }
-        if $::osfamily == 'RedHat' {
-          include mongodb::client
-        }
+        -> class { 'mongodb::client': }
       EOS
 
       apply_manifest_on(hosts.reverse, pp, catch_failures: true)
@@ -145,9 +211,16 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
     it 'sets up the replset with puppet' do
       pp = <<~EOS
         mongodb_replset { 'test':
-          auth_enabled => true,
-          members      => [#{hosts.map { |x| "'#{x}:27017'" }.join(',')}],
-          before       => Mongodb_user['admin']
+          members => [#{hosts.map { |x| "'#{x}:27017'" }.join(',')}],
+        }
+        -> mongodb_user { "User admin on db admin":
+          ensure        => present,
+          password_hash => mongodb_password('admin', 'password'),
+          username      => 'admin',
+          database      => 'admin',
+          roles         => ['userAdmin', 'readWrite', 'dbAdmin', 'dbAdminAnyDatabase', 'readAnyDatabase',
+          'readWriteAnyDatabase', 'userAdminAnyDatabase', 'clusterAdmin',
+          'clusterManager', 'clusterMonitor', 'hostManager', 'root', 'restore',],
         }
       EOS
       apply_manifest_on(hosts_as('master'), pp, catch_failures: true)
@@ -156,11 +229,112 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
         expect(r.stdout).to match %r{#{hosts[0]}:27017}
         expect(r.stdout).to match %r{#{hosts[1]}:27017}
       end
+      sleep(30)
+      on(hosts_as('slave'), 'mongosh --quiet --eval "load(\'/root/.mongoshrc.js\');EJSON.stringify(rs.conf())"') do |r|
+        expect(r.stdout).to match %r{#{hosts[0]}:27017}
+        expect(r.stdout).to match %r{#{hosts[1]}:27017}
+      end
     end
 
     it 'inserts data on the master' do
+      on hosts_as('master'), %{mongosh test --verbose --eval 'load("/root/.mongoshrc.js");db.dummyData.insertOne({"created_by_puppet": 1})'}
+    end
+
+    it 'checks the data on the master' do
+      on hosts_as('master'), %{mongosh test --verbose --eval 'load("/root/.mongoshrc.js");EJSON.stringify(db.dummyData.findOne())'} do |r|
+        expect(r.stdout).to match %r{created_by_puppet}
+      end
+    end
+
+    it 'checks the data on the slave' do
+      sleep(10)
+      on hosts_as('slave'), %{mongosh test --verbose --eval 'load("/root/.mongoshrc.js");db.getMongo().setReadPref("primaryPreferred");EJSON.stringify(db.dummyData.findOne())'} do |r|
+        expect(r.stdout).to match %r{created_by_puppet}
+      end
+    end
+  end
+
+  describe 'mongodb::server with replset_members and auth => true' do
+    after :all do
+      pp = <<-EOS
+        class { 'mongodb::globals':
+          #{repo_ver_param}
+        }
+        -> class { 'mongodb::server':
+          ensure => absent,
+          package_ensure => purged,
+          service_ensure => stopped
+        }
+        -> class { 'mongodb::client':
+          ensure => purged
+        }
+      EOS
+
+      apply_manifest_on(hosts.reverse, pp, catch_failures: true)
+    end
+
+    let(:keyfile_path) do
+      os_family = fact('os.family')
+      if os_family == 'RedHat'
+        '/var/lib/mongo'
+      else
+        '/var/lib/mongodb'
+      end
+    end
+
+    it 'configures mongo on both nodes' do
+      pp = <<~EOS
+        class { 'mongodb::globals':
+          #{repo_ver_param}
+        }
+        -> class { 'mongodb::client': }
+        -> class { 'mongodb::server':
+          admin_username => 'admin',
+          admin_password => 'password',
+          auth           => true,
+          store_creds    => true,
+          create_admin   => true,
+          bind_ip        => ['0.0.0.0'],
+          replset        => 'test',
+          replset_members => [#{hosts.map { |x| "'#{x}:27017'" }.join(',')}],
+          keyfile        => "#{keyfile_path}/mongodb-keyfile",
+          key            => '+dxlTrury7xtD0FRqFf3YWGnKqWAtlyauuemxuYuyz9POPUuX1Uj3chGU8MFMHa7
+        UxASqex7NLMALQXHL+Th4T3dyb6kMZD7KiMcJObO4M+JLiX9drcTiifsDEgGMi7G
+        vYn3pWSm5TTDrHJw7RNWfMHw3sHk0muGQcO+0dWv3sDJ6SiU8yOKRtYcTEA15GbP
+        ReDZuHFy1T1qhk5NIt6pTtPGsZKSm2wAWIOa2f2IXvpeQHhjxP8aDFb3fQaCAqOD
+        R7hrimqq0Nickfe8RLA89iPXyadr/YeNBB7w7rySatQBzwIbBUVGNNA5cxCkwyx9
+        E5of3xi7GL9xNxhQ8l0JEpofd4H0y0TOfFDIEjc7cOnYlKAHzBgog4OcFSILgUaF
+        kHuTMtv0pj+MMkW2HkeXETNII9XE1+JiZgHY08G7yFEJy87ttUoeKmpbI6spFz5U
+        4K0amj+N6SOwXaS8uwp6kCqay0ERJLnw+7dKNKZIZdGCrrBxcZ7wmR/wLYrxvHhZ
+        QpeXTxgD5ebwCR0cf3Xnb5ql5G/HHKZDq8LTFHwELNh23URGPY7K7uK+IF6jSEhq
+        V2H3HnWV9teuuJ5he9BB/pLnyfjft6KUUqE9HbaGlX0f3YBk/0T3S2ESN4jnfRTQ
+        ysAKvQ6NasXkzqXktu8X4fS5QNqrFyqKBZSWxttfJBKXnT0TxamCKLRx4AgQglYo
+        3KRoyfxXx6G+AjP1frDJxFAFEIgEFqRk/FFuT/y9LpU+3cXYX1Gt6wEatgmnBM3K
+        g+Bybk5qHv1b7M8Tv9/I/BRXcpLHeIkMICMY8sVPGmP8xzL1L3i0cws8p5h0zPBa
+        YG/QX0BmltAni8owgymFuyJgvr/gaRX4WHbKFD+9nKpqJ3ocuVNuCDsxDqLsJEME
+        nc1ohyB0lNt8lHf1U00mtgDSV3fwo5LkwhRi6d+bDBTL/C6MZETMLdyCqDlTdUWG
+        YXIsJ0gYcu9XG3mx10LbdPJvxSMg',
+        }
+      EOS
+
+      apply_manifest_on(hosts, pp, catch_failures: true)
+      apply_manifest_on(hosts, pp, catch_changes: true)
+    end
+
+    it 'sets up the replset with puppet' do
+      on(hosts_as('master'), 'mongosh --quiet --eval "load(\'/root/.mongoshrc.js\');EJSON.stringify(rs.conf())"') do |r|
+        expect(r.stdout).to match %r{#{hosts[0]}:27017}
+        expect(r.stdout).to match %r{#{hosts[1]}:27017}
+      end
       sleep(30)
-      on hosts_as('master'), %{mongosh test --verbose --eval 'load("/root/.mongoshrc.js");db.dummyData.insert({"created_by_puppet": 1})'}
+      on(hosts_as('slave'), 'mongosh --quiet --eval "load(\'/root/.mongoshrc.js\');EJSON.stringify(rs.conf())"') do |r|
+        expect(r.stdout).to match %r{#{hosts[0]}:27017}
+        expect(r.stdout).to match %r{#{hosts[1]}:27017}
+      end
+    end
+
+    it 'inserts data on the master' do
+      on hosts_as('master'), %{mongosh test --verbose --eval 'load("/root/.mongoshrc.js");db.dummyData.insertOne({"created_by_puppet": 1})'}
     end
 
     it 'checks the data on the master' do

--- a/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
@@ -38,7 +38,7 @@ describe Puppet::Type.type(:mongodb_database).provider(:mongodb) do
     tmp = Tempfile.new('test')
     mongodconffile = tmp.path
     allow(provider.class).to receive(:mongod_conf_file).and_return(mongodconffile)
-    allow(provider.class).to receive(:mongo_eval).with('db.getMongo().setReadPref("primaryPreferred");EJSON.stringify(db.getMongo().getDBs())').and_return(raw_dbs)
+    allow(provider.class).to receive(:mongo_eval).with('EJSON.stringify(db.getMongo().getDBs())').and_return(raw_dbs)
     allow(provider.class).to receive(:db_ismaster).and_return(true)
   end
 

--- a/spec/unit/puppet/provider/mongodb_shard/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_shard/mongodb_spec.rb
@@ -20,21 +20,23 @@ describe Puppet::Type.type(:mongodb_shard).provider(:mongo) do
 
   let(:raw_shards) do
     {
-      'sharding version' => {
-        '_id' => 1,
-        'version' => 4,
-        'minCompatibleVersion' => 4,
-        'currentVersion' => 5,
-        'clusterId' => "ObjectId('548e9110f3aca177c94c5e49')"
-      },
-      'shards' => [
-        {  '_id' => 'rs_test', 'host' => 'rs_test/mongo1:27018' }
-      ],
-      'databases' => [
-        {  '_id' => 'admin', 'partitioned' => false, 'primary' => 'config' },
-        {  '_id' => 'test', 'partitioned' => false, 'primary' => 'rs_test' },
-        {  '_id' => 'rs_test', 'partitioned' => true, 'primary' => 'rs_test' }
-      ]
+      'value' => {
+        'sharding version' => {
+          '_id' => 1,
+          'version' => 4,
+          'minCompatibleVersion' => 4,
+          'currentVersion' => 5,
+          'clusterId' => "ObjectId('548e9110f3aca177c94c5e49')"
+        },
+        'shards' => [
+          {  '_id' => 'rs_test', 'host' => 'rs_test/mongo1:27018' }
+        ],
+        'databases' => [
+          {  '_id' => 'admin', 'partitioned' => false, 'primary' => 'config' },
+          {  '_id' => 'test', 'partitioned' => false, 'primary' => 'rs_test' },
+          {  '_id' => 'rs_test', 'partitioned' => true, 'primary' => 'rs_test' }
+        ]
+      }
     }
   end
 


### PR DESCRIPTION
Fixing integration test that haven't been run for a very long time.
To be able to run integration test that require two hosts with gha I have created a custom ci workflow and set it to unmanaged in modulesync.

