### PR TITLE
Backslashes in a password need to be escaped

### DIFF
--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -85,6 +85,24 @@ describe 'mongodb::server class', if: supported_version?(default[:platform], rep
   end
 
   describe 'installation using authentication' do
+    after :all do
+      pp = <<-EOS
+        class { 'mongodb::globals':
+          #{repo_ver_param}
+        }
+        -> class { 'mongodb::server':
+          ensure         => absent,
+          package_ensure => purged,
+          service_ensure => stopped
+        }
+        -> class { 'mongodb::client':
+          ensure => purged
+        }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+    end
+
     it 'works with no errors' do
       pp = <<-EOS
         class { 'mongodb::globals':
@@ -142,6 +160,67 @@ describe 'mongodb::server class', if: supported_version?(default[:platform], rep
       it { is_expected.to be_grouped_into 'root' }
       it { is_expected.to be_mode 600 }
       it { is_expected.to contain 'admin.auth(\'admin\', \'password\')' }
+    end
+
+    describe command("mongosh admin --quiet --eval \"load('/root/.mongoshrc.js');EJSON.stringify(db.getUser('admin')['customData'])\"") do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match "{\"createdBy\":\"Puppet Mongodb_user['User admin on db admin']\"}\n" }
+    end
+
+    describe command('mongod --version') do
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+
+  describe 'installation using authentication with complex password' do
+    it 'works with no errors' do
+      pp = <<-EOS
+        class { 'mongodb::globals':
+        #{repo_ver_param}
+        }
+        -> class { 'mongodb::server':
+          auth           => true,
+          create_admin   => true,
+          handle_creds   => true,
+          store_creds    => true,
+          admin_username => 'admin',
+          admin_password => 'admin_\\_password',
+          restart        => true,
+        }
+        class { 'mongodb::client': }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe package(package_name) do
+      it { is_expected.to be_installed }
+    end
+
+    describe file(config_file) do
+      it { is_expected.to be_file }
+    end
+
+    describe service(service_name) do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe port(27_017) do
+      it { is_expected.to be_listening }
+    end
+
+    describe command('mongosh --quiet --eval "db.serverCmdLineOpts().ok"') do
+      its(:stderr) { is_expected.to match %r{requires authentication} }
+    end
+
+    describe file('/root/.mongoshrc.js') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_owned_by 'root' }
+      it { is_expected.to be_grouped_into 'root' }
+      it { is_expected.to be_mode 600 }
+      it { is_expected.to contain 'admin.auth(\'admin\', \'admin_\\\\_password\')' }
     end
 
     describe command("mongosh admin --quiet --eval \"load('/root/.mongoshrc.js');EJSON.stringify(db.getUser('admin')['customData'])\"") do

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -184,7 +184,7 @@ describe 'mongodb::server class', if: supported_version?(default[:platform], rep
           handle_creds   => true,
           store_creds    => true,
           admin_username => 'admin',
-          admin_password => 'admin_\\_password',
+          admin_password => 'admin_\\\\_\\'_"_&_password',
           restart        => true,
         }
         class { 'mongodb::client': }
@@ -220,7 +220,7 @@ describe 'mongodb::server class', if: supported_version?(default[:platform], rep
       it { is_expected.to be_owned_by 'root' }
       it { is_expected.to be_grouped_into 'root' }
       it { is_expected.to be_mode 600 }
-      it { is_expected.to contain 'admin.auth(\'admin\', \'admin_\\\\_password\')' }
+      it { is_expected.to contain 'admin.auth(\'admin\', \'admin_\\\\_\\\'_"_&_password\')' }
     end
 
     describe command("mongosh admin --quiet --eval \"load('/root/.mongoshrc.js');EJSON.stringify(db.getUser('admin')['customData'])\"") do

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -452,6 +452,22 @@ describe 'mongodb::server' do
               with_mode('0600').
               with_content(%r{admin\.auth\('admin', 'password'\)})
           }
+
+          context 'with backslash in password' do
+            let :params do
+              {
+                admin_username: 'admin',
+                admin_password: 'password_\_with_backslash',
+                auth: true,
+                store_creds: true
+              }
+            end
+
+            it {
+              is_expected.to contain_file('/root/.mongoshrc.js').
+                with_content(%r{admin\.auth\('admin', 'password_\\\\_with_backslash'\)})
+            }
+          end
         end
 
         context 'false' do

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -453,11 +453,11 @@ describe 'mongodb::server' do
               with_content(%r{admin\.auth\('admin', 'password'\)})
           }
 
-          context 'with backslash in password' do
+          context 'with complex password' do
             let :params do
               {
                 admin_username: 'admin',
-                admin_password: 'password_\_with_backslash',
+                admin_password: 'complex_\\_\'_"_&_password',
                 auth: true,
                 store_creds: true
               }
@@ -465,7 +465,7 @@ describe 'mongodb::server' do
 
             it {
               is_expected.to contain_file('/root/.mongoshrc.js').
-                with_content(%r{admin\.auth\('admin', 'password_\\\\_with_backslash'\)})
+                with_content(%r{admin\.auth\('admin', 'complex_\\\\_\\'_"_&_password'\)})
             }
           end
         end

--- a/templates/mongoshrc.js.erb
+++ b/templates/mongoshrc.js.erb
@@ -34,7 +34,7 @@ if (authRequired()) {
   <%- end -%>
   try {
     admin = db.getSiblingDB('admin')
-    admin.auth('<%= @admin_username %>', '<%= @admin_password_unsensitive.gsub('\\','\\\\\\\\') %>')
+    admin.auth('<%= @admin_username %>', '<%= @admin_password_unsensitive.gsub('\\','\\\\\\\\').gsub("'","\\\\'") %>')
   }
   catch (err) {
     // Silently ignore this error, we can't really do anything about it.

--- a/templates/mongoshrc.js.erb
+++ b/templates/mongoshrc.js.erb
@@ -34,7 +34,7 @@ if (authRequired()) {
   <%- end -%>
   try {
     admin = db.getSiblingDB('admin')
-    admin.auth('<%= @admin_username %>', '<%= @admin_password_unsensitive %>')
+    admin.auth('<%= @admin_username %>', '<%= @admin_password_unsensitive.gsub('\\','\\\\\\\\') %>')
   }
   catch (err) {
     // Silently ignore this error, we can't really do anything about it.


### PR DESCRIPTION
This will replace a single backslash with a double backslash in the `/root/.mongoshrc.js` file. when a password with a backslash is used, it is correctly passed on to the provider for setting the user's password, but things break when attempting to use said password for the admin user.

A small explanation on the amount of backslashes: The first argument is a regular expression, so we need to escape the backslash. The second argument allows for references to capture groups or the entire match using backslashes, for example `\0` contains the entire match.  This would make us end up with 4 backslashes, but apparantly the template rendering also has backslash escaping, this we need to double the amount of backslashes. So 8 in total.