### PR TITLE
Fix secondary users on a replicaset being marked as changed

### DIFF
--- a/spec/acceptance/replset_spec.rb
+++ b/spec/acceptance/replset_spec.rb
@@ -347,5 +347,19 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
         expect(r.stdout).to match %r{created_by_puppet}
       end
     end
+
+    it 'create a user' do
+      pp = <<-EOS
+        mongodb_user {'testuser':
+          ensure        => present,
+          password_hash => mongodb_password('testuser', 'passw0rd'),
+          database      => 'testdb',
+          roles         => ['readWrite', 'dbAdmin'],
+        }
+      EOS
+
+      apply_manifest_on(hosts, pp, catch_failures: true)
+      apply_manifest_on(hosts, pp, catch_changes: true)
+    end
   end
 end

--- a/spec/acceptance/replset_spec.rb
+++ b/spec/acceptance/replset_spec.rb
@@ -73,6 +73,20 @@ if hosts.length > 1 && supported_version?(default[:platform], repo_version)
         expect(r.stdout).to match %r{some value}
       end
     end
+
+    it 'create a user' do
+      pp = <<-EOS
+        mongodb_user {'testuser':
+          ensure        => present,
+          password_hash => mongodb_password('testuser', 'passw0rd'),
+          database      => 'testdb',
+          roles         => ['readWrite', 'dbAdmin'],
+        }
+      EOS
+
+      apply_manifest_on(hosts, pp, catch_failures: true)
+      apply_manifest_on(hosts, pp, catch_changes: true)
+    end
   end
 
   describe 'mongodb::server with replset_members' do

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -71,13 +71,6 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
     end
   end
 
-  describe 'empty self.instances from slave' do
-    it 'doesn`t retrun array of users' do
-      allow(provider.class).to receive(:db_ismaster).and_return(false)
-      expect(provider.class.instances).to be_empty
-    end
-  end
-
   describe 'create' do
     it 'creates a user' do
       cmd_json = <<-EOS.gsub(%r{^\s*}, '').gsub(%r{$\n}, '')


### PR DESCRIPTION
This PR fixes mongodb_user resources keeping status changed on secondary nodes.

The first commit adds the acceptance test, showing the issue. The second one fixes the test by updating the provider.