### PR TITLE
Move default version to repo.pp

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -77,7 +77,7 @@ class mongodb::globals (
   Optional[String[1]] $version        = undef,
   Optional[String[1]] $client_version = undef,
   Boolean $manage_package_repo        = true,
-  String[1] $repo_version             = '5.0',
+  Optional[String[1]] $repo_version   = undef,
   Boolean $use_enterprise_repo        = false,
   Optional[String] $repo_location     = undef,
   Optional[String] $keyring_location  = undef,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -38,7 +38,7 @@ class mongodb::repo (
   Optional[String[1]] $proxy_password   = undef,
 ) {
   if $version == undef and $repo_location == undef {
-    fail('`version` or `repo_location` is required')
+    $version = '5.0'
   }
   if $version != undef and $repo_location != undef {
     fail('`version` is not supported with `repo_location`')


### PR DESCRIPTION
#### Pull Request (PR) description
Default version in globals.pp doesn't allow to use repo_location and having repo_location doesn't work at all, because it fails on check, as version is always defined
`  if $version != undef and $repo_location != undef {
    fail('version' is not supported with 'repo_location')
  }`
To fix this I propose to set default version only if both $version and $repo_location are undef.

#### This Pull Request (PR) fixes the following issues
One can't use repo_location setting
