### PR TITLE
fix regex to allow database names to contain "-" in role@db syntax

### DIFF
--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -42,7 +42,7 @@ Puppet::Type.newtype(:mongodb_user) do
   newproperty(:roles, array_matching: :all) do
     desc "The user's roles."
     defaultto ['dbAdmin']
-    newvalue(%r{^\w+(@\w+)?$})
+    newvalue(%r{^\w+(@[\w-]+)?$})
 
     # Pretty output for arrays.
     def should_to_s(value)


### PR DESCRIPTION
#### Pull Request (PR) description
Fix regex in lib/puppet/type/mongodb_user.rb to allow the same database names as allowed in lib/puppet/type/mongodb_database.rb

#### This Pull Request (PR) fixes the following issues
Fixes #771
