### PR TITLE
remove EOL OSes

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -19,8 +18,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "9"
       ]
     },
@@ -48,7 +45,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]
@@ -56,7 +52,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
         "22.04"
       ]
     },


### PR DESCRIPTION
#### Pull Request (PR) description
Removing the following EOL operating systems

CentOS 7
CentOS 8
RedHat 7
Debian 10
Ubuntu 20.04
