### PR TITLE
Update default repo version to latest supported by OS

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -176,8 +176,8 @@ Default value: `true`
 Data type: `String[1]`
 
 The version of the package repo.
-
-Default value: `'5.0'`
+If not specified, the module will default to the latest supported version for your OS distro.
+When `repo_location` is specified `repo_version` is ignored.
 
 ##### <a name="-mongodb--globals--use_enterprise_repo"></a>`use_enterprise_repo`
 

--- a/data/Debian-11.yaml
+++ b/data/Debian-11.yaml
@@ -1,0 +1,2 @@
+---
+mongodb::globals::repo_version: '7.0'

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -1,4 +1,5 @@
 ---
+mongodb::globals::repo_version: '8.0'
 mongodb::server::user: 'mongodb'
 mongodb::server::group: 'mongodb'
 mongodb::server::dbpath: '/var/lib/mongodb'

--- a/data/Linux-family.yaml
+++ b/data/Linux-family.yaml
@@ -1,5 +1,6 @@
 ---
 # Amazon uses os family Linux
+mongodb::globals::repo_version: '8.0'
 mongodb::server::user: 'mongod'
 mongodb::server::group: 'mongod'
 mongodb::server::dbpath: '/var/lib/mongodb'

--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -1,4 +1,5 @@
 ---
+mongodb::globals::repo_version: '8.0'
 mongodb::server::user: 'mongod'
 mongodb::server::group: 'mongod'
 mongodb::server::dbpath: '/var/lib/mongo'

--- a/data/Suse-12.yaml
+++ b/data/Suse-12.yaml
@@ -1,0 +1,2 @@
+---
+mongodb::globals::repo_version: '7.0'

--- a/data/Suse-family.yaml
+++ b/data/Suse-family.yaml
@@ -1,4 +1,5 @@
 ---
+mongodb::globals::repo_version: '8.0'
 mongodb::server::user: 'mongod'
 mongodb::server::group: 'mongod'
 mongodb::server::dbpath: '/var/lib/mongodb'

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -50,6 +50,8 @@
 #
 # @param repo_version
 #   The version of the package repo.
+#   If not specified, the module will default to the latest supported version for your OS distro.
+#   When `repo_location` is specified `repo_version` is ignored.
 #
 # @param use_enterprise_repo
 #   When manage_package_repo is set to true, this setting indicates if it will use the Community Edition
@@ -74,10 +76,10 @@
 #   This sets the password for the proxyserver, should authentication be required
 #
 class mongodb::globals (
+  String[1] $repo_version,
   Optional[String[1]] $version        = undef,
   Optional[String[1]] $client_version = undef,
   Boolean $manage_package_repo        = true,
-  String[1] $repo_version             = '5.0',
   Boolean $use_enterprise_repo        = false,
   Optional[String] $repo_location     = undef,
   Optional[String] $keyring_location  = undef,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,9 +40,6 @@ class mongodb::repo (
   if $version == undef and $repo_location == undef {
     fail('`version` or `repo_location` is required')
   }
-  if $version != undef and $repo_location != undef {
-    fail('`version` is not supported with `repo_location`')
-  }
   if $version != undef and versioncmp($version, '4.4') < 0 {
     fail('Package repositories for versions older than 4.4 are unsupported')
   }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -273,10 +273,7 @@ describe 'mongodb::server' do
           }
         end
 
-        it do
-          config_data = YAML.safe_load(catalogue.resource("File[#{config_file}]")[:content])
-          expect(config_data['storage']['journal']['enabled']).to be(true)
-        end
+        it { is_expected.to raise_error(Puppet::Error) }
       end
 
       describe 'with journal: false' do
@@ -286,10 +283,7 @@ describe 'mongodb::server' do
           }
         end
 
-        it do
-          config_data = YAML.safe_load(catalogue.resource("File[#{config_file}]")[:content])
-          expect(config_data['storage']['journal']['enabled']).to be(false)
-        end
+        it { is_expected.to raise_error(Puppet::Error) }
       end
 
       describe 'with journal and package_version < 7.0.0' do
@@ -300,10 +294,7 @@ describe 'mongodb::server' do
           }
         end
 
-        it do
-          config_data = YAML.safe_load(catalogue.resource("File[#{config_file}]")[:content])
-          expect(config_data['storage']['journal']['enabled']).to be(true)
-        end
+        it { is_expected.to raise_error(Puppet::Error) }
       end
 
       describe 'with journal and package_version >= 7.0.0' do
@@ -317,6 +308,31 @@ describe 'mongodb::server' do
         it { is_expected.to raise_error(Puppet::Error) }
       end
 
+      describe 'with journal and user defined repo_version < 7.0' do
+        let :params do
+          {
+            journal: true
+          }
+        end
+        let(:pre_condition) do
+          [
+            'class mongodb::globals {
+              $manage_package_repo = true
+              $version = undef
+              $edition = "org"
+              $repo_version = "6.0"
+              $repo_location = undef
+            }',
+            'class{"mongodb::globals": }'
+          ]
+        end
+
+        it do
+          config_data = YAML.safe_load(catalogue.resource("File[#{config_file}]")[:content])
+          expect(config_data['storage']['journal']['enabled']).to be(true)
+        end
+      end
+
       describe 'with journal and user defined repo_location without version' do
         let :params do
           {
@@ -327,7 +343,7 @@ describe 'mongodb::server' do
           [
             'class mongodb::globals {
               $manage_package_repo = true
-              $version = "5.0"
+              $version = undef
               $edition = "org"
               $repo_location = "https://repo.myorg.com/"
             }',
@@ -341,6 +357,53 @@ describe 'mongodb::server' do
         end
       end
 
+      describe 'with journal, package_version < 7.0.0 and user defined repo_location without version' do
+        let :params do
+          {
+            package_ensure: '6.0.0',
+            journal: true
+          }
+        end
+        let(:pre_condition) do
+          [
+            'class mongodb::globals {
+              $manage_package_repo = true
+              $version = undef
+              $edition = "org"
+              $repo_location = "https://repo.myorg.com/"
+            }',
+            'class{"mongodb::globals": }'
+          ]
+        end
+
+        it do
+          config_data = YAML.safe_load(catalogue.resource("File[#{config_file}]")[:content])
+          expect(config_data['storage']['journal']['enabled']).to be(true)
+        end
+      end
+
+      describe 'with journal, package_version >= 7.0.0 and user defined repo_location without version' do
+        let :params do
+          {
+            package_ensure: '7.0.0',
+            journal: true
+          }
+        end
+        let(:pre_condition) do
+          [
+            'class mongodb::globals {
+              $manage_package_repo = true
+              $version = undef
+              $edition = "org"
+              $repo_location = "https://repo.myorg.com/"
+            }',
+            'class{"mongodb::globals": }'
+          ]
+        end
+
+        it { is_expected.to raise_error(Puppet::Error) }
+      end
+
       describe 'with journal and user defined repo_location with version < 7.0' do
         let :params do
           {
@@ -351,7 +414,7 @@ describe 'mongodb::server' do
           [
             'class mongodb::globals {
               $manage_package_repo = true
-              $version = "5.0"
+              $version = undef
               $edition = "org"
               $repo_location = "https://repo.myorg.com/6.0/"
             }',
@@ -375,7 +438,7 @@ describe 'mongodb::server' do
           [
             'class mongodb::globals {
               $manage_package_repo = true
-              $version = "5.0"
+              $version = undef
               $edition = "org"
               $repo_location = "https://repo.myorg.com/7.0/"
             }',


### PR DESCRIPTION
#### Pull Request (PR) description
MongoDB 5.0 is EOL and the default in mongodb::globals has to be changes.
The latest version is 8.0 but that version is not supported on all OSes.
Because of this I have moved the default to hiera data.

#### This Pull Request (PR) fixes the following issues
Fixes #754 
