### PR TITLE
Improve Handling of sensitive Data

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2009,7 +2009,7 @@ Type: Ruby 4.x API
 
 Get the mongodb password hash from the clear text password.
 
-#### `mongodb_password(String[1] $username, Variant[String[1], Sensitive[String[1]]] $password, Optional[Boolean] $sensitive)`
+#### `mongodb_password(String[1] $username, Variant[String[1], Sensitive[String[1]]] $password)`
 
 Get the mongodb password hash from the clear text password.
 
@@ -2024,12 +2024,6 @@ Data type: `String[1]`
 ##### `password`
 
 Data type: `Variant[String[1], Sensitive[String[1]]]`
-
-
-
-##### `sensitive`
-
-Data type: `Optional[Boolean]`
 
 
 

--- a/lib/puppet/functions/mongodb_password.rb
+++ b/lib/puppet/functions/mongodb_password.rb
@@ -7,11 +7,11 @@ Puppet::Functions.create_function(:mongodb_password) do
   dispatch :mongodb_password do
     required_param 'String[1]', :username
     required_param 'Variant[String[1], Sensitive[String[1]]]', :password
-    optional_param 'Boolean', :sensitive
     return_type 'Variant[String, Sensitive[String]]'
   end
 
-  def mongodb_password(username, password, sensitive = false)
+  def mongodb_password(username, password)
+    sensitive = password.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
     password = password.unwrap if password.respond_to?(:unwrap)
     result_string = Puppet::Util::MongodbMd5er.md5(username, password)
     if sensitive

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -41,7 +41,7 @@ define mongodb::db (
     }
 
     if $password_hash {
-      $hash = $password_hash.unwrap
+      $hash = $password_hash
     } elsif $password {
       $hash = mongodb_password($user, $password)
     } else {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -434,7 +434,7 @@ class mongodb::server (
     mongodb::db { 'admin':
       user            => $admin_username,
       auth_mechanism  => $admin_auth_mechanism,
-      password        => $admin_password.unwrap,
+      password        => $admin_password,
       password_hash   => $admin_password_hash,
       roles           => $admin_roles,
       update_password => $admin_update_password,

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -81,7 +81,7 @@ describe 'mongodb::server' do
           {
             create_admin: true,
             admin_username: 'admin',
-            admin_password: 'password'
+            admin_password: sensitive('password')
           }
         end
 
@@ -90,7 +90,7 @@ describe 'mongodb::server' do
         it do
           is_expected.to contain_mongodb__db('admin').
             with_user('admin').
-            with_password('password').
+            with_password(sensitive('password')).
             with_roles(%w[userAdmin readWrite dbAdmin dbAdminAnyDatabase readAnyDatabase
                           readWriteAnyDatabase userAdminAnyDatabase clusterAdmin clusterManager
                           clusterMonitor hostManager root restore])
@@ -104,7 +104,7 @@ describe 'mongodb::server' do
           {
             create_admin: true,
             admin_username: 'admin',
-            admin_password_hash: 'xxx89adfaxd'
+            admin_password_hash: sensitive('xxx89adfaxd')
           }
         end
 
@@ -113,7 +113,7 @@ describe 'mongodb::server' do
         it do
           is_expected.to contain_mongodb__db('admin').
             with_user('admin').
-            with_password_hash('xxx89adfaxd').
+            with_password_hash(sensitive('xxx89adfaxd')).
             with_roles(%w[userAdmin readWrite dbAdmin dbAdminAnyDatabase readAnyDatabase
                           readWriteAnyDatabase userAdminAnyDatabase clusterAdmin clusterManager
                           clusterMonitor hostManager root restore])
@@ -501,7 +501,7 @@ describe 'mongodb::server' do
           let :params do
             {
               admin_username: 'admin',
-              admin_password: 'password',
+              admin_password: sensitive('password'),
               auth: true,
               store_creds: true
             }
@@ -513,14 +513,14 @@ describe 'mongodb::server' do
               with_owner('root').
               with_group('root').
               with_mode('0600').
-              with_content(%r{admin\.auth\('admin', 'password'\)})
+              with_content(sensitive(%r{admin\.auth\('admin', 'password'\)}))
           }
 
           context 'with complex password' do
             let :params do
               {
                 admin_username: 'admin',
-                admin_password: 'complex_\\_\'_"_&_password',
+                admin_password: sensitive('complex_\\_\'_"_&_password'),
                 auth: true,
                 store_creds: true
               }
@@ -528,7 +528,7 @@ describe 'mongodb::server' do
 
             it {
               is_expected.to contain_file('/root/.mongoshrc.js').
-                with_content(%r{admin\.auth\('admin', 'complex_\\\\_\\'_"_&_password'\)})
+                with_content(sensitive(%r{admin\.auth\('admin', 'complex_\\\\_\\'_"_&_password'\)}))
             }
           end
         end

--- a/spec/defines/db_spec.rb
+++ b/spec/defines/db_spec.rb
@@ -14,7 +14,7 @@ describe 'mongodb::db' do
 
         let(:params) do
           { 'user'     => 'testuser',
-            'password' => 'testpass' }
+            'password' => sensitive('testpass') }
         end
 
         it 'contains mongodb_database with mongodb::server requirement' do
@@ -35,9 +35,9 @@ describe 'mongodb::db' do
         end
 
         it 'prefers password_hash instead of password' do
-          params['password_hash'] = 'securehash'
+          params['password_hash'] = sensitive('securehash')
           is_expected.to contain_mongodb_user('User testuser on db testdb'). \
-            with_password_hash('securehash')
+            with_password_hash(sensitive('securehash'))
         end
 
         it 'contains mongodb_database with proper tries param' do
@@ -53,7 +53,7 @@ describe 'mongodb::db' do
           {
             'db_name'  => 'testdb',
             'user'     => 'testuser',
-            'password' => 'testpass'
+            'password' => sensitive('testpass')
           }
         end
 
@@ -75,9 +75,9 @@ describe 'mongodb::db' do
         end
 
         it 'prefers password_hash instead of password' do
-          params['password_hash'] = 'securehash'
+          params['password_hash'] = sensitive('securehash')
           is_expected.to contain_mongodb_user('User testuser on db testdb'). \
-            with_password_hash('securehash')
+            with_password_hash(sensitive('securehash'))
         end
 
         it 'contains mongodb_database with proper tries param' do

--- a/spec/functions/mongodb_password_spec.rb
+++ b/spec/functions/mongodb_password_spec.rb
@@ -8,7 +8,6 @@ describe 'mongodb_password' do
   it { is_expected.to run.with_params(:undef, :undef).and_raise_error(ArgumentError) }
   it { is_expected.to run.with_params('', '').and_raise_error(ArgumentError) }
   it { is_expected.to run.with_params('user', 'pass').and_return('e0c4a7b97d4db31f5014e9694e567d6b') }
-  it { is_expected.to run.with_params('user', sensitive('pass')).and_return('e0c4a7b97d4db31f5014e9694e567d6b') }
-  it { is_expected.to run.with_params('user', sensitive('pass'), true) }
-  it { expect(subject.execute('user', sensitive('pass'), true).unwrap).to eq('e0c4a7b97d4db31f5014e9694e567d6b') }
+  it { is_expected.to run.with_params('user', sensitive('pass')).and_return(sensitive('e0c4a7b97d4db31f5014e9694e567d6b')) }
+  it { expect(subject.execute('user', sensitive('pass'))).to eq(sensitive('e0c4a7b97d4db31f5014e9694e567d6b')) }
 end

--- a/templates/mongoshrc.js.epp
+++ b/templates/mongoshrc.js.epp
@@ -34,7 +34,8 @@ if (authRequired()) {
   <%- } -%>
   try {
     admin = db.getSiblingDB('admin')
-    admin.auth('<%= $mongodb::server::config::admin_username %>', '<%= $mongodb::server::config::admin_password.regsubst('\\\\','\\\\\\\\','G').regsubst("'","\\\\'",'G') %>')
+    <%# TODO: we need to unwrap and re-wrap until Openvox-regsubst flawlessly accepts Sensitive, like Puppet-regsubst does.  (PR pending: https://github.com/OpenVoxProject/openvox/pull/354) %>
+    admin.auth('<%= $mongodb::server::config::admin_username %>', '<%= Sensitive($mongodb::server::config::admin_password.unwrap.regsubst('\\\\','\\\\\\\\','G').regsubst("'","\\\\'",'G')) %>')
   }
   catch (err) {
     // Silently ignore this error, we can't really do anything about it.


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Remove unneeded `unwrap`

As soon as Openvox-regsubst flawlessly accepts Sensitive, like Puppet-regsubst does.  ([PR pending](https://github.com/OpenVoxProject/openvox/pull/354)) the original Line in `templates/mongoshrc.js.epp` can be restored:
```
    admin.auth('<%= $mongodb::server::config::admin_username %>', '<%= $mongodb::server::config::admin_password.regsubst('\\\\','\\\\\\\\','G').regsubst("'","\\\\'",'G') %>')
```

