### PR TITLE
mongos: add RuntimeDirectory to systemd unit file

### DIFF
--- a/manifests/mongos/service.pp
+++ b/manifests/mongos/service.pp
@@ -66,7 +66,7 @@ class mongodb::mongos::service (
 
   if $service_manage {
     systemd::unit_file { 'mongos.service':
-      content => epp($service_template, { service_user => $service_user, service_group => $service_user }),
+      content => epp($service_template, { service_user => $service_user, service_group => $service_group }),
       enable  => $real_service_enable,
     } ~> Service['mongos']
 

--- a/spec/classes/mongos_spec.rb
+++ b/spec/classes/mongos_spec.rb
@@ -32,7 +32,14 @@ describe 'mongodb::mongos' do
 
         # service
         it { is_expected.to contain_class('mongodb::mongos::service') }
+
         it { is_expected.to contain_service('mongos') }
+
+        it {
+          is_expected.to contain_systemd__unit_file('mongos.service')
+            .with_content(%r{RuntimeDirectory=mongodb})
+            .with_content(%r{RuntimeDirectoryMode=0755})
+        }
       end
 
       describe 'with specific bind_ip values' do

--- a/templates/mongos/mongos.service-dropin.epp
+++ b/templates/mongos/mongos.service-dropin.epp
@@ -9,6 +9,8 @@ Documentation=https://docs.mongodb.org/manual
 After=network.target
 
 [Service]
+RuntimeDirectory=mongodb
+RuntimeDirectoryMode=0755
 User=<%= $service_user %>
 Group=<%= $service_group %>
 Environment="OPTIONS=-f /etc/mongos.conf"


### PR DESCRIPTION
This adds RuntimeDirectory and RuntimeDirectoryMode to the mongos systemd unit file template to ensure /run/mongodb is created with the correct permissions.

Also fixes a bug in the mongos service manifest where service_group was incorrectly passed as service_user to the unit file template.

